### PR TITLE
Add ability to create UTexture from Image http links. 

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -27,8 +27,22 @@ namespace ERequestContentType
 	};
 }
 
+
+/** Content type returned by the request */
+UENUM(BlueprintType)
+namespace ERequestResultType
+{
+	enum Type
+	{
+		JSON,
+		TEXTURE
+	};
+}
+
 /** Generate a delegates for callback events */
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRequestComplete);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnRequestCompleteAsJSON, class UVaRestJsonObject*, JsonObject, bool, IsValid, FString, Text );
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnRequestCompleteAsTexture, class UTexture2D*, Texture, bool, IsValid );
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRequestFail);
 
 /**
@@ -49,7 +63,7 @@ public:
 
 	/** Creates new request with defined verb and content type */
 	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest")
-	static UVaRestRequestJSON* ConstructRequestExt(UObject* WorldContextObject, ERequestVerb::Type Verb, ERequestContentType::Type ContentType);
+	static UVaRestRequestJSON* ConstructRequestExt(UObject* WorldContextObject, ERequestVerb::Type Verb, ERequestContentType::Type ContentType, ERequestResultType::Type ResultType);
 
 	/** Set verb to the request */
 	UFUNCTION(BlueprintCallable, Category = "VaRest")
@@ -59,6 +73,11 @@ public:
 	 * params/constaints should be defined as key=ValueString pairs from Json data */
 	UFUNCTION(BlueprintCallable, Category = "VaRest")
 	void SetContentType(ERequestContentType::Type ContentType);
+
+	/** Set result type to the request. If you're using the x-www-form-urlencoded, 
+	 * params/constaints should be defined as key=ValueString pairs from Json data */
+	UFUNCTION(BlueprintCallable, Category = "VaRest")
+	void SetResultType(ERequestResultType::Type ResultType);
 
 	/** Sets optional header info */
 	UFUNCTION(BlueprintCallable, Category = "VaRest")
@@ -80,11 +99,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "VaRest")
 	void ResetRequestData();
 
-	/** Reset saved response data */
-	UFUNCTION(BlueprintCallable, Category = "VaRest")
-	void ResetResponseData();
-
-
 	//////////////////////////////////////////////////////////////////////////
 	// JSON data accessors
 
@@ -95,15 +109,6 @@ public:
 	/** Set the Request Json object */
 	UFUNCTION(BlueprintCallable, Category = "VaRest")
 	void SetRequestObject(UVaRestJsonObject* JsonObject);
-
-	/** Get the Response Json object */
-	UFUNCTION(BlueprintCallable, Category = "VaRest")
-	UVaRestJsonObject* GetResponseObject();
-
-	/** Set the Response Json object */
-	UFUNCTION(BlueprintCallable, Category = "VaRest")
-	void SetResponseObject(UVaRestJsonObject* JsonObject);
-
 
 	//////////////////////////////////////////////////////////////////////////
 	// URL processing
@@ -124,33 +129,26 @@ private:
 	void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 
 public:
-	/** Event occured when the request has been completed */
+	/** Event occured when the request has been completed successfully and JSON is expected*/
 	UPROPERTY(BlueprintAssignable, Category = "VaRest")
-	FOnRequestComplete OnRequestComplete;
+	FOnRequestCompleteAsJSON OnRequestCompleteJSON;
+
+	/** Event occured when the request has been completed successfully and Texture is expected */
+	UPROPERTY(BlueprintAssignable, Category = "VaRest")
+	FOnRequestCompleteAsTexture OnRequestCompleteTexture;
 
 	/** Event occured when the request wasn't successfull */
 	UPROPERTY(BlueprintAssignable, Category = "VaRest")
-	FOnRequestComplete OnRequestFail;
-
-
+	FOnRequestFail OnRequestFail;
+	
 	//////////////////////////////////////////////////////////////////////////
 	// Data
 
 public:
-	/** Request response stored as a string */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "VaRest")
-	FString ResponseContent;
-
-	/** Is the response valid JSON? */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "VaRest")
-	bool bIsValidJsonResponse;
 
 private:
 	/** Internal request data stored as JSON */
 	UVaRestJsonObject* RequestJsonObj;
-
-	/** Responce data stored as JSON */
-	UVaRestJsonObject* ResponseJsonObj;
 
 	/** Verb for making request (GET,POST,etc) */
 	ERequestVerb::Type RequestVerb;
@@ -158,7 +156,13 @@ private:
 	/** Content type to be applied for request */
 	ERequestContentType::Type RequestContentType;
 
+	/** Content type returned by request */
+	ERequestResultType::Type RequestResultType;
+
 	/** Mapping of header section to values. Used to generate final header string for request */
 	TMap<FString, FString> RequestHeaders;
+
+    /** Helper function to convert raw data to UTexture **/ 
+	UTexture2D* ImageFactory(TArray<uint8> Data); 
 
 };

--- a/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
@@ -1,6 +1,7 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
 
 #include "VaRestPluginPrivatePCH.h"
+#include "ImageWrapper.h"
 
 UVaRestRequestJSON::UVaRestRequestJSON(const class FPostConstructInitializeProperties& PCIP)
 	: Super(PCIP)
@@ -19,13 +20,14 @@ UVaRestRequestJSON* UVaRestRequestJSON::ConstructRequest(UObject* WorldContextOb
 UVaRestRequestJSON* UVaRestRequestJSON::ConstructRequestExt(
 	UObject* WorldContextObject, 
 	ERequestVerb::Type Verb, 
-	ERequestContentType::Type ContentType)
+	ERequestContentType::Type ContentType,ERequestResultType::Type ResultType)
 {
 	UVaRestRequestJSON* Request = ConstructRequest(WorldContextObject);
 
 	Request->SetVerb(Verb);
 	Request->SetContentType(ContentType);
-
+	Request->SetResultType(ResultType);
+	
 	return Request;
 }
 
@@ -38,6 +40,12 @@ void UVaRestRequestJSON::SetContentType(ERequestContentType::Type ContentType)
 {
 	RequestContentType = ContentType;
 }
+
+void UVaRestRequestJSON::SetResultType(ERequestResultType::Type ResultType)
+{
+	RequestResultType = ResultType; 
+}
+
 
 void UVaRestRequestJSON::SetHeader(const FString& HeaderName, const FString& HeaderValue)
 {
@@ -80,7 +88,6 @@ FString UVaRestRequestJSON::PercentEncode(const FString& Text)
 void UVaRestRequestJSON::ResetData()
 {
 	ResetRequestData();
-	ResetResponseData();
 }
 
 void UVaRestRequestJSON::ResetRequestData()
@@ -95,21 +102,6 @@ void UVaRestRequestJSON::ResetRequestData()
 	}
 }
 
-void UVaRestRequestJSON::ResetResponseData()
-{
-	if (ResponseJsonObj != NULL)
-	{
-		ResponseJsonObj->Reset();
-	}
-	else
-	{
-		ResponseJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
-	}
-
-	bIsValidJsonResponse = false;
-}
-
-
 //////////////////////////////////////////////////////////////////////////
 // JSON data accessors
 
@@ -122,17 +114,6 @@ void UVaRestRequestJSON::SetRequestObject(UVaRestJsonObject* JsonObject)
 {
 	RequestJsonObj = JsonObject;
 }
-
-UVaRestJsonObject* UVaRestRequestJSON::GetResponseObject()
-{
-	return ResponseJsonObj;
-}
-
-void UVaRestRequestJSON::SetResponseObject(UVaRestJsonObject* JsonObject)
-{
-	ResponseJsonObj = JsonObject;
-}
-
 
 //////////////////////////////////////////////////////////////////////////
 // URL processing
@@ -235,10 +216,8 @@ void UVaRestRequestJSON::ProcessRequest(TSharedRef<IHttpRequest> HttpRequest)
 
 void UVaRestRequestJSON::OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
 {
-	// Be sure that we have no data from previous response
-	ResetResponseData();
 
-	// Check we have result to process futher
+	// Check we have result to process further
 	if (!bWasSuccessful)
 	{
 		UE_LOG(LogVaRest, Error, TEXT("Request failed: %s"), *Request->GetURL());
@@ -249,30 +228,62 @@ void UVaRestRequestJSON::OnProcessRequestComplete(FHttpRequestPtr Request, FHttp
 		return;
 	}
 
-	// Save response data as a string
-	ResponseContent = Response->GetContentAsString();
-
-	// Log response state
-	UE_LOG(LogVaRest, Log, TEXT("Response (%d): %s"), Response->GetResponseCode(), *Response->GetContentAsString());
-
-	// Try to deserialize data to JSON
-	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(ResponseContent);
-	FJsonSerializer::Deserialize(JsonReader, ResponseJsonObj->GetRootObject());
-
-	// Decide whether the request was successful
-	bIsValidJsonResponse = bWasSuccessful && ResponseJsonObj->GetRootObject().IsValid();
-
-	// Log errors
-	if (!bIsValidJsonResponse)
+	if ( RequestResultType == ERequestResultType::JSON )
 	{
-		if (!ResponseJsonObj->GetRootObject().IsValid())
+		UVaRestJsonObject* ResponseJsonObj  = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+		// Try to deserialize data to JSON
+		TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(Response->GetContentAsString());
+		FJsonSerializer::Deserialize(JsonReader, ResponseJsonObj->GetRootObject());
+
+		// Decide whether the request was successful
+		bool bIsValidJsonResponse = bWasSuccessful && ResponseJsonObj->GetRootObject().IsValid();
+
+		// Log errors
+		if (!bIsValidJsonResponse)
 		{
-			// As we assume it's recommended way to use current class, but not the only one,
-			// it will be the warning instead of error
-			UE_LOG(LogVaRest, Warning, TEXT("JSON could not be decoded!"));
+			if (!ResponseJsonObj->GetRootObject().IsValid())
+			{
+				// As we assume it's recommended way to use current class, but not the only one,
+				// it will be the warning instead of error
+				UE_LOG(LogVaRest, Warning, TEXT("JSON could not be decoded!"));
+			}
 		}
+
+		// Broadcast the result event
+		OnRequestCompleteJSON.Broadcast(ResponseJsonObj, bIsValidJsonResponse, Response->GetContentAsString()); 
+	}
+	else if ( RequestResultType == ERequestResultType::TEXTURE )
+	{
+		UTexture2D* Texture =  ImageFactory(Response->GetContent()); 
+		OnRequestCompleteTexture.Broadcast(Texture, Texture != nullptr); 
 	}
 
-	// Broadcast the result event
-	OnRequestComplete.Broadcast();
+}
+
+UTexture2D* UVaRestRequestJSON::ImageFactory(TArray<uint8> Data)
+{
+	IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>( FName("ImageWrapper") );
+	// Note: PNG format.  Other formats are supported
+	IImageWrapperPtr ImageWrapper = ImageWrapperModule.CreateImageWrapper( EImageFormat::PNG );
+	if ( ImageWrapper.IsValid() && ImageWrapper->SetCompressed( Data.GetData(), Data.Num() ) )
+	{
+		const TArray<uint8>* UncompressedBGRA = NULL;
+		if ( ImageWrapper->GetRaw( ERGBFormat::BGRA, 8, UncompressedBGRA) )
+		{
+			// Create the UTexture for rendering
+			UTexture2D* Texture = UTexture2D::CreateTransient( ImageWrapper->GetWidth(), ImageWrapper->GetHeight(), PF_B8G8R8A8 );
+
+			// Fill in the source data from the file
+			uint8* TextureData = (uint8*)Texture->PlatformData->Mips[0].BulkData.Lock( LOCK_READ_WRITE );
+			FMemory::Memcpy( TextureData, UncompressedBGRA->GetData(), UncompressedBGRA->Num() );
+			Texture->PlatformData->Mips[0].BulkData.Unlock();
+
+			// Update the rendering resource from data.
+			Texture->UpdateResource();
+
+			return Texture;
+		}
+	}
+	// Add code here to support more formats. 
+	return nullptr; 
 }

--- a/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
+++ b/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
@@ -17,7 +17,7 @@ UVaRestParseManager* UVaRestParseManager::ConstructParseRequest(
 	ERequestVerb::Type Verb,
 	ERequestContentType::Type ContentType)
 {
-	return (UVaRestParseManager*)ConstructRequestExt(WorldContextObject, Verb, ContentType);
+	return (UVaRestParseManager*)ConstructRequestExt(WorldContextObject, Verb, ContentType,ERequestResultType::JSON);
 }
 
 void UVaRestParseManager::ProcessParseURL(

--- a/Source/VaRestPlugin/VaRestPlugin.Build.cs
+++ b/Source/VaRestPlugin/VaRestPlugin.Build.cs
@@ -30,7 +30,9 @@ namespace UnrealBuildTool.Rules
 					"Core",
 					"CoreUObject",
 					"Engine",
-                    "HTTP"
+                    "HTTP",
+                    "Json",
+                    "ImageWrapper"
 					// ... add other public dependencies that you statically link with here ...
 				});
 		}


### PR DESCRIPTION
-  Add the concept of RequestResultType (JSON & Texture) and broadcast relevant OnCompleted Event accordingly.
-  Refactor - Remove Response UVaRestJsonObject as member variable. Only Create UVaRestJsonObject/UTexture when explicitly asked.
- Only PNG format for now - adding more formats should be trivial. 

For Example: 

![image](https://cloud.githubusercontent.com/assets/4664618/4608840/a7ee0e66-528a-11e4-8b5d-04962e686c56.png)

CAVEAT: This will break existing blueprints/code.

TODO: Possibly refactor completety and decouple UVaRestRequestJSON request from result TYPE. The Request perhaps only outputs raw TArray data and other classes work on that raw data. 
