### PR TITLE
added ConstructPointerObject function which returns a UVaRestJsonObject

### DIFF
--- a/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
+++ b/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
@@ -28,9 +28,13 @@ class UVaRestParseManager : public UVaRestRequestJSON
 	//////////////////////////////////////////////////////////////////////////
 	// Quering helpers
 
-	/** Create Json record that contains Pointer to the Parse Object */
+	/** Create Json string that contains Pointer to the Parse Object */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Parse")
 	static FString ConstructPointer(const FString& ClassName, const FString& ObjectId);
+
+	/** Create Json object that contains Pointer to the Parse Object */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Parse")
+	static UVaRestJsonObject* ConstructPointerObject(const FString& ClassName, const FString& ObjectId);
 
 	/** Construct simple WHERE query that contains only one condition.
 	 * Attn!! String Values should containt quotes! */

--- a/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
+++ b/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
@@ -72,6 +72,17 @@ FString UVaRestParseManager::ConstructPointer(const FString& ClassName, const FS
 	return FString::Printf(TEXT("{\"__type\":\"Pointer\",\"className\":\"%s\",\"objectId\":\"%s\"}"), *ClassName, *ObjectId);
 }
 
+UVaRestJsonObject* UVaRestParseManager::ConstructPointerObject(const FString& ClassName, const FString& ObjectId)
+{
+	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+
+	OutRestJsonObj->SetStringField(TEXT("__type"), TEXT("Pointer"));
+	OutRestJsonObj->SetStringField(TEXT("className"), ClassName);
+	OutRestJsonObj->SetStringField(TEXT("objectId"), ObjectId);
+
+	return OutRestJsonObj;
+}
+
 FString UVaRestParseManager::ConstructWhereQuerySimple(const FString& Key, const FString& Value)
 {
 	return FString::Printf(TEXT("where={\"%s\":%s}"), *Key, *Value);


### PR DESCRIPTION
We're finding that pointers that are created using the ConstructPointer method are causing errors when trying to save them in pointer fields in Parse. The typical error we get back says that it expected a pointer but received a string. This makes sense since the ConstructPointer method returns a string.

It seems to work better if you pass an object to pointer fields, so I've added a method called ConstructPointerObject that does the equivalent of ConstructPointer but returns an object instead of a string. I'm interested to know what the use case for the version of ConstructPointer that returns a string.
