### PR TITLE
- added a method to create a Parse field deletion operation object

### DIFF
--- a/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
+++ b/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
@@ -33,8 +33,12 @@ class UVaRestParseManager : public UVaRestRequestJSON
 	static FString ConstructPointer(const FString& ClassName, const FString& ObjectId);
 
 	/** Create Json object that contains Pointer to the Parse Object */
-	UFUNCTION(BlueprintCallable, Category = "VaRest|Parse")
+	UFUNCTION(BlueprintPure, Category = "VaRest|Parse")
 	static UVaRestJsonObject* ConstructPointerObject(const FString& ClassName, const FString& ObjectId);
+
+	/** Create Json object that instructs Parse to delete whatever field it is set to */
+	UFUNCTION(BlueprintPure, Category = "VaRest|Parse")
+	static UVaRestJsonObject* ConstructDeleteOperation();
 
 	/** Construct simple WHERE query that contains only one condition.
 	 * Attn!! String Values should containt quotes! */

--- a/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
+++ b/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
@@ -83,6 +83,15 @@ UVaRestJsonObject* UVaRestParseManager::ConstructPointerObject(const FString& Cl
 	return OutRestJsonObj;
 }
 
+UVaRestJsonObject* UVaRestParseManager::ConstructDeleteOperation()
+{
+	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	
+	OutRestJsonObj->SetStringField(TEXT("__op"), TEXT("Delete"));
+	
+	return OutRestJsonObj;
+}
+
 FString UVaRestParseManager::ConstructWhereQuerySimple(const FString& Key, const FString& Value)
 {
 	return FString::Printf(TEXT("where={\"%s\":%s}"), *Key, *Value);


### PR DESCRIPTION
I added a convenience method to create an object that can be set to a Parse field to delete it.

See the section here about deleting a single field for details:

https://parse.com/docs/rest#objects-deleting

I also switched the ConstructPointerObject method to be BlueprintPure.
