### PR TITLE
added DELETE request verb

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -12,7 +12,8 @@ namespace ERequestVerb
 	{
 		GET,
 		POST,
-		PUT
+		PUT,
+		DELETE
 	};
 }
 

--- a/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
@@ -161,6 +161,10 @@ void UVaRestRequestJSON::ProcessRequest(TSharedRef<IHttpRequest> HttpRequest)
 	case ERequestVerb::PUT:
 		HttpRequest->SetVerb("PUT");
 		break;
+			
+	case ERequestVerb::DELETE:
+		HttpRequest->SetVerb("DELETE");
+		break;
 
 	default:
 		break;


### PR DESCRIPTION
I added support for requests that use the DELETE HTTP verb in order to allow us to delete Parse objects:

https://parse.com/docs/rest#objects-deleting