### PR TITLE
fixed syntax error on when building on windows

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -13,7 +13,7 @@ namespace ERequestVerb
 		GET,
 		POST,
 		PUT,
-		DELETE
+		DEL UMETA(DisplayName="DELETE")
 	};
 }
 

--- a/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
@@ -162,7 +162,7 @@ void UVaRestRequestJSON::ProcessRequest(TSharedRef<IHttpRequest> HttpRequest)
 		HttpRequest->SetVerb("PUT");
 		break;
 			
-	case ERequestVerb::DELETE:
+	case ERequestVerb::DEL:
 		HttpRequest->SetVerb("DELETE");
 		break;
 


### PR DESCRIPTION
My last commit (3879f39b9be9551c7c82458a195d936c9722c879) generated syntax errors when building on Windows. This fixes the errors.