### PR TITLE
added UPROPERTY declaration to request and response objects

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -148,9 +148,11 @@ public:
 
 private:
 	/** Internal request data stored as JSON */
+	UPROPERTY()
 	UVaRestJsonObject* RequestJsonObj;
 
-	/** Responce data stored as JSON */
+	/** Response data stored as JSON */
+	UPROPERTY()
 	UVaRestJsonObject* ResponseJsonObj;
 
 	/** Verb for making request (GET,POST,etc) */


### PR DESCRIPTION
I'm finding that without this, the request and response objects are liable to be cleaned up by garbage collection before the request is finished running.

Without these UPROPERTY declarations, I'm finding that if you create a request, process it and then immediately open a new level, your app will crash when the request finishes because the response json object has been garbage collected.