### PR TITLE
new functions: Facebook auth object and GetFieldNames

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
@@ -45,6 +45,10 @@ class UVaRestJsonObject : public UObject
 	//////////////////////////////////////////////////////////////////////////
 	// FJsonObject API
 
+	/** Returns a list of field names that exist in the object */
+	UFUNCTION(BlueprintPure, Category = "VaRest|Json")
+	TArray<FString> GetFieldNames();
+
 	/** Checks to see if the FieldName exists in the object */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
 	bool HasField(const FString& FieldName) const;

--- a/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
@@ -72,6 +72,10 @@ class UVaRestJsonObject : public UObject
 	/** Set an ObjectField named FieldName and value of Json Array */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
 	void SetArrayField(const FString& FieldName, const TArray<UVaRestJsonValue*>& InArray);
+	
+	/** Adds all of the fields from one json object to this one */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
+	void MergeJsonObject(UVaRestJsonObject* InJsonObject, bool Overwrite);
 
 
 	//////////////////////////////////////////////////////////////////////////

--- a/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
+++ b/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
@@ -44,6 +44,10 @@ class UVaRestParseManager : public UVaRestRequestJSON
 	UFUNCTION(BlueprintPure, Category = "VaRest|Parse")
 	static UVaRestJsonObject* ConstructDeleteOperation();
 
+	/** Create Json object that contains Facebook auth data */
+	UFUNCTION(BlueprintPure, Category = "VaRest|Parse")
+	static UVaRestJsonObject* ConstructFacebookAuthDataObject(FString UserId, FString AccessToken, FString ExpirationDate);
+
 	/** Construct simple WHERE query that contains only one condition.
 	 * Attn!! String Values should containt quotes! */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Parse")

--- a/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
@@ -268,6 +268,21 @@ void UVaRestJsonObject::SetArrayField(const FString& FieldName, const TArray<UVa
 	JsonObj->SetArrayField(FieldName, ValArray);
 }
 
+void UVaRestJsonObject::MergeJsonObject(UVaRestJsonObject* InJsonObject, bool Overwrite)
+{
+	TArray<FString> Keys = InJsonObject->GetFieldNames();
+	
+	for (auto Key : Keys)
+	{
+		if (Overwrite == false && HasField(Key))
+		{
+			continue;
+		}
+		
+		SetField(Key, InJsonObject->GetField(Key));
+	}
+}
+
 UVaRestJsonObject* UVaRestJsonObject::GetObjectField(const FString& FieldName) const
 {
 	if (!JsonObj.IsValid())

--- a/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
@@ -74,6 +74,20 @@ bool UVaRestJsonObject::DecodeJson(const FString& JsonString)
 //////////////////////////////////////////////////////////////////////////
 // FJsonObject API
 
+TArray<FString> UVaRestJsonObject::GetFieldNames()
+{
+	TArray<FString> Result;
+	
+	if (!JsonObj.IsValid())
+	{
+		return Result;
+	}
+	
+	JsonObj->Values.GetKeys(Result);
+	
+	return Result;
+}
+
 bool UVaRestJsonObject::HasField(const FString& FieldName) const
 {
 	if (!JsonObj.IsValid())

--- a/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
+++ b/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
@@ -102,6 +102,21 @@ UVaRestJsonObject* UVaRestParseManager::ConstructDeleteOperation()
 	return OutRestJsonObj;
 }
 
+UVaRestJsonObject* UVaRestParseManager::ConstructFacebookAuthDataObject(FString UserId, FString AccessToken, FString ExpirationDate)
+{
+	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	
+	UVaRestJsonObject* FacebookJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	
+	FacebookJsonObj->SetStringField(TEXT("id"), UserId);
+	FacebookJsonObj->SetStringField(TEXT("access_token"), AccessToken);
+	FacebookJsonObj->SetStringField(TEXT("expiration_date"), ExpirationDate);
+	
+	OutRestJsonObj->SetObjectField(TEXT("facebook"), FacebookJsonObj);
+	
+	return OutRestJsonObj;
+}
+
 FString UVaRestParseManager::ConstructWhereQuerySimple(const FString& Key, const FString& Value)
 {
 	return FString::Printf(TEXT("where={\"%s\":%s}"), *Key, *Value);


### PR DESCRIPTION
I added a helper function to create Facebook AuthData objects. This can be used to link users to sign users into their Parse accounts using their Facebook accounts. See here for details:

https://parse.com/docs/rest/guide#users-linking-users

I also added a function to UVaRestJsonObject that retrieves all of the fields in the object.