### PR TITLE
4.8 compatibility

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
@@ -16,7 +16,7 @@ class UVaRestJsonObject : public UObject
 	GENERATED_UCLASS_BODY()
 
 	/** Create new Json object */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Object", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Object", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonObject* ConstructJsonObject(UObject* WorldContextObject);
 
 	/** Reset all internal data */

--- a/Source/VaRestPlugin/Classes/Json/VaRestJsonValue.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestJsonValue.h
@@ -35,23 +35,23 @@ class UVaRestJsonValue : public UObject
 
 	/** Create new Json Number value
 	 * Attn.!! float used instead of double to make the function blueprintable! */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Number Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Number Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonValue* ConstructJsonValueNumber(UObject* WorldContextObject, float Number);
 
 	/** Create new Json String value */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json String Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json String Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonValue* ConstructJsonValueString(UObject* WorldContextObject, const FString& StringValue);
 
 	/** Create new Json Bool value */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Bool Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Bool Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonValue* ConstructJsonValueBool(UObject* WorldContextObject, bool InValue);
 
 	/** Create new Json Array value */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Array Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Array Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonValue* ConstructJsonValueArray(UObject* WorldContextObject, const TArray<UVaRestJsonValue*>& InArray);
 
 	/** Create new Json Object value */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Object Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Object Value", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Json")
 	static UVaRestJsonValue* ConstructJsonValueObject(UObject* WorldContextObject, UVaRestJsonObject *JsonObject);
 
 	/** Create new Json value from FJsonValue (to be used from VaRestJsonObject) */

--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -45,11 +45,11 @@ public:
 	// Construction
 
 	/** Creates new request (totally empty) */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Request (Empty)", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Request (Empty)", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest")
 	static UVaRestRequestJSON* ConstructRequest(UObject* WorldContextObject);
 
 	/** Creates new request with defined verb and content type */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Json Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Json Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest")
 	static UVaRestRequestJSON* ConstructRequestExt(UObject* WorldContextObject, ERequestVerb::Type Verb, ERequestContentType::Type ContentType);
 
 	/** Set verb to the request */

--- a/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
+++ b/Source/VaRestPlugin/Classes/Parse/VaRestParseManager.h
@@ -13,7 +13,7 @@ class UVaRestParseManager : public UVaRestRequestJSON
 	GENERATED_UCLASS_BODY()
 
 	/** Creates new Parse request with defined verb and content type */
-	UFUNCTION(BlueprintPure, meta = (FriendlyName = "Construct Parse Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Parse")
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct Parse Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|Parse")
 	static UVaRestParseManager* ConstructParseRequest(UObject* WorldContextObject, ERequestVerb::Type Verb, ERequestContentType::Type ContentType);
 
 	/** Open the Parse URL (Attn.!! App Id and Api Key should be set before) */

--- a/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestJsonObject.cpp
@@ -13,7 +13,7 @@ UVaRestJsonObject::UVaRestJsonObject(const class FObjectInitializer& PCIP)
 
 UVaRestJsonObject* UVaRestJsonObject::ConstructJsonObject(UObject* WorldContextObject)
 {
-	return (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	return NewObject<UVaRestJsonObject>();
 }
 
 void UVaRestJsonObject::Reset()
@@ -117,7 +117,7 @@ UVaRestJsonValue* UVaRestJsonObject::GetField(const FString& FieldName) const
 
 	TSharedPtr<FJsonValue> NewVal = JsonObj->TryGetField(FieldName);
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -208,7 +208,7 @@ TArray<UVaRestJsonValue*> UVaRestJsonObject::GetArrayField(const FString& FieldN
 	TArray< TSharedPtr<FJsonValue> > ValArray = JsonObj->GetArrayField(FieldName);
 	for (auto Value : ValArray)
 	{
-		UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+		UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 		NewValue->SetRootValue(Value);
 
 		OutArray.Add(NewValue);
@@ -292,7 +292,7 @@ UVaRestJsonObject* UVaRestJsonObject::GetObjectField(const FString& FieldName) c
 
 	TSharedPtr<FJsonObject> JsonObjField = JsonObj->GetObjectField(FieldName);
 
-	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
 	OutRestJsonObj->SetRootObject(JsonObjField);
 
 	return OutRestJsonObj;
@@ -431,7 +431,7 @@ TArray<UVaRestJsonObject*> UVaRestJsonObject::GetObjectArrayField(const FString&
 	{
 		TSharedPtr<FJsonObject> NewObj = Value->AsObject();
 
-		UVaRestJsonObject* NewJson = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+		UVaRestJsonObject* NewJson = NewObject<UVaRestJsonObject>();
 		NewJson->SetRootObject(NewObj);
 
 		OutArray.Add(NewJson);

--- a/Source/VaRestPlugin/Private/Json/VaRestJsonValue.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestJsonValue.cpp
@@ -12,7 +12,7 @@ UVaRestJsonValue* UVaRestJsonValue::ConstructJsonValueNumber(UObject* WorldConte
 {
 	TSharedPtr<FJsonValue> NewVal = MakeShareable(new FJsonValueNumber(Number));
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -22,7 +22,7 @@ UVaRestJsonValue* UVaRestJsonValue::ConstructJsonValueString(UObject* WorldConte
 {
 	TSharedPtr<FJsonValue> NewVal = MakeShareable(new FJsonValueString(StringValue));
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -32,7 +32,7 @@ UVaRestJsonValue* UVaRestJsonValue::ConstructJsonValueBool(UObject* WorldContext
 {
 	TSharedPtr<FJsonValue> NewVal = MakeShareable(new FJsonValueBoolean(InValue));
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -49,7 +49,7 @@ UVaRestJsonValue* UVaRestJsonValue::ConstructJsonValueArray(UObject* WorldContex
 
 	TSharedPtr<FJsonValue> NewVal = MakeShareable(new FJsonValueArray(ValueArray));
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -59,7 +59,7 @@ UVaRestJsonValue* UVaRestJsonValue::ConstructJsonValueObject(UObject* WorldConte
 {
 	TSharedPtr<FJsonValue> NewVal = MakeShareable(new FJsonValueObject(JsonObject->GetRootObject()));
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -69,7 +69,7 @@ UVaRestJsonValue* ConstructJsonValue(UObject* WorldContextObject, const TSharedP
 {
 	TSharedPtr<FJsonValue> NewVal = InValue;
 
-	UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+	UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 	NewValue->SetRootValue(NewVal);
 
 	return NewValue;
@@ -215,7 +215,7 @@ TArray<UVaRestJsonValue*> UVaRestJsonValue::AsArray() const
 	TArray< TSharedPtr<FJsonValue> > ValArray = JsonVal->AsArray();
 	for (auto Value : ValArray)
 	{
-		UVaRestJsonValue* NewValue = (UVaRestJsonValue*)StaticConstructObject(UVaRestJsonValue::StaticClass());
+		UVaRestJsonValue* NewValue = NewObject<UVaRestJsonValue>();
 		NewValue->SetRootValue(Value);
 
 		OutArray.Add(NewValue);
@@ -234,7 +234,7 @@ UVaRestJsonObject* UVaRestJsonValue::AsObject()
 
 	TSharedPtr<FJsonObject> NewObj = JsonVal->AsObject();
 
-	UVaRestJsonObject* JsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* JsonObj = NewObject<UVaRestJsonObject>();
 	JsonObj->SetRootObject(NewObj);
 
 	return JsonObj;

--- a/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
@@ -13,7 +13,7 @@ UVaRestRequestJSON::UVaRestRequestJSON(const class FObjectInitializer& PCIP)
 
 UVaRestRequestJSON* UVaRestRequestJSON::ConstructRequest(UObject* WorldContextObject)
 {
-	return (UVaRestRequestJSON*)StaticConstructObject(UVaRestRequestJSON::StaticClass());
+	return NewObject<UVaRestRequestJSON>();
 }
 
 UVaRestRequestJSON* UVaRestRequestJSON::ConstructRequestExt(
@@ -91,7 +91,7 @@ void UVaRestRequestJSON::ResetRequestData()
 	}
 	else
 	{
-		RequestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+		RequestJsonObj = NewObject<UVaRestJsonObject>();
 	}
 }
 
@@ -103,7 +103,7 @@ void UVaRestRequestJSON::ResetResponseData()
 	}
 	else
 	{
-		ResponseJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+		ResponseJsonObj = NewObject<UVaRestJsonObject>();
 	}
 
 	bIsValidJsonResponse = false;

--- a/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
+++ b/Source/VaRestPlugin/Private/Parse/VaRestParseManager.cpp
@@ -74,7 +74,7 @@ FString UVaRestParseManager::ConstructPointer(const FString& ClassName, const FS
 
 UVaRestJsonObject* UVaRestParseManager::ConstructPointerObject(const FString& ClassName, const FString& ObjectId)
 {
-	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
 
 	OutRestJsonObj->SetStringField(TEXT("__type"), TEXT("Pointer"));
 	OutRestJsonObj->SetStringField(TEXT("className"), ClassName);
@@ -85,7 +85,7 @@ UVaRestJsonObject* UVaRestParseManager::ConstructPointerObject(const FString& Cl
 
 UVaRestJsonObject* UVaRestParseManager::ConstructDateObject(const FDateTime& Date)
 {
-	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
 
 	OutRestJsonObj->SetStringField(TEXT("__type"), TEXT("Date"));
 	OutRestJsonObj->SetStringField(TEXT("iso"), Date.ToIso8601());
@@ -95,7 +95,7 @@ UVaRestJsonObject* UVaRestParseManager::ConstructDateObject(const FDateTime& Dat
 
 UVaRestJsonObject* UVaRestParseManager::ConstructDeleteOperation()
 {
-	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
 	
 	OutRestJsonObj->SetStringField(TEXT("__op"), TEXT("Delete"));
 	
@@ -104,9 +104,9 @@ UVaRestJsonObject* UVaRestParseManager::ConstructDeleteOperation()
 
 UVaRestJsonObject* UVaRestParseManager::ConstructFacebookAuthDataObject(FString UserId, FString AccessToken, FString ExpirationDate)
 {
-	UVaRestJsonObject* OutRestJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
 	
-	UVaRestJsonObject* FacebookJsonObj = (UVaRestJsonObject*)StaticConstructObject(UVaRestJsonObject::StaticClass());
+	UVaRestJsonObject* FacebookJsonObj = NewObject<UVaRestJsonObject>();
 	
 	FacebookJsonObj->SetStringField(TEXT("id"), UserId);
 	FacebookJsonObj->SetStringField(TEXT("access_token"), AccessToken);


### PR DESCRIPTION
I've done a pass for 4.8 compatibility:

1. The StaticConstructObject function has been deprecated. The NewObject function is preferred, so I've made this change everywhere StaticConstructObject is used.

2. The FriendlyName meta tag for blueprint functions has been deprecated in favour of DisplayName, so I've made this change as well.