### PR TITLE
PlayFab BackEnd Service Integration Added

### DIFF
--- a/Source/VaRestPlugin/Classes/PlayFab/VaRestPlayFabManager.h
+++ b/Source/VaRestPlugin/Classes/PlayFab/VaRestPlayFabManager.h
@@ -65,382 +65,409 @@ class UVaRestPlayFabManager : public UVaRestRequestJSON
 
 	// Authentication
 
-	/** Create Json object that contains play fab login data */
+	/** Signs the user into the PlayFab account, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithPlayFab(FString Username, FString Password);
+		static UVaRestPlayFabManager* ConstructLoginWithPlayFab(FString Username, FString Password);
 
-	/** Create Json object that contains play fab login data */
+	/** Registers a new Playfab user account, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructRegisterWithPlayFab(FString Username, FString Password, FString Email);
+		static UVaRestPlayFabManager* ConstructRegisterWithPlayFab(FString Username, FString Password, FString Email);
 
-	/** Create Get Photon Authentication Toeken Request */
+	/** Gets a Photon custom authentication token that can be used to securely join the player into a Photon room */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructGetPhotonAuthenticationToken(FString SessionTicket, bool PhotonRealtime, bool PhotonTurnbased, bool PhotonChat);
+		static UVaRestPlayFabManager* ConstructGetPhotonAuthenticationToken(FString SessionTicket, bool PhotonRealtime, bool PhotonTurnbased, bool PhotonChat);
 
-	/** Create a Login with Android Device Request */
+	/** Signs the user in using the Android device identifier, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithAndroidDeviceID(FString AndroidDeviceId, FString OSVersion = "", FString AndroidDeviceType = "", bool CreateAccount = false);
+		static UVaRestPlayFabManager* ConstructLoginWithAndroidDeviceID(FString AndroidDeviceId, FString OSVersion = "", FString AndroidDeviceType = "", bool CreateAccount = false);
 
-	/** Create Login with email request */
+	/** Signs the user into the PlayFab account, returning a session identifier that can subsequently be used for API calls which require an authenticated user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithEmail(FString Username, FString Password);
+		static UVaRestPlayFabManager* ConstructLoginWithEmail(FString Username, FString Password);
 
-	/** Create a Login with Facebook request */
+	/** Signs the user in using a Facebook access token, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithFacebook(FString FacebookAccessToken, bool CreateAccount = false);
+		static UVaRestPlayFabManager* ConstructLoginWithFacebook(FString FacebookAccessToken, bool CreateAccount = false);
 
-	/** Create a Login with Google request */
+	/** Signs the user in using a Google account access token, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithGoogle(FString GoogleAccessToken, bool CreateAccount = false);
+		static UVaRestPlayFabManager* ConstructLoginWithGoogle(FString GoogleAccessToken, bool CreateAccount = false);
 
-	/** Create a Login with IOS Device Request */
+	/** Signs the user in using the vendor-specific iOS device identifier, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithIOSDeviceID(FString IOSDeviceId, FString OSVersion = "", FString DeviceModel = "", bool CreateAccount = false);
+		static UVaRestPlayFabManager* ConstructLoginWithIOSDeviceID(FString IOSDeviceId, FString OSVersion = "", FString DeviceModel = "", bool CreateAccount = false);
 
-	/** Create a Login with Steam request */
+	/** Signs the user in using a Steam authentication ticket, returning a session identifier that can subsequently be used for API calls which require an authenticated user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
-	static UVaRestPlayFabManager* ConstructLoginWithSteam(FString SteamAccessToken, bool CreateAccount = false);
+		static UVaRestPlayFabManager* ConstructLoginWithSteam(FString SteamAccessToken, bool CreateAccount = false);
 
 	// Account Management
 
-	/** Add Username Password Request */
+	/** Adds playfab username/password auth to an existing semi-anonymous account created via a 3rd party auth method.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
-	static UVaRestPlayFabManager* ConstructAddUsernamePassword(FString SessionTicket, FString Email, FString Username, FString Password);
+		static UVaRestPlayFabManager* ConstructAddUsernamePassword(FString SessionTicket, FString Email, FString Username, FString Password);
 
-	/** Get Account Info Request */
+	/** Retrieves the user's PlayFab account details  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
-	static UVaRestPlayFabManager* ConstructGetAccountInfo(FString SessionTicket, FString PlayFabId, FString Username = "", FString Email = "", FString TitleDisplayName = "");
+		static UVaRestPlayFabManager* ConstructGetAccountInfo(FString SessionTicket, FString PlayFabId, FString Username = "", FString Email = "", FString TitleDisplayName = "");
 	
-	/** Get Play Fab Ids from Facebook Ids */
+	/** Retrieves the unique PlayFab identifiers for the given set of Facebook identifiers */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
-	static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromFacebookIDs(FString SessionTicket, TArray<FString> FacebookIDs);
+		static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromFacebookIDs(FString SessionTicket, TArray<FString> FacebookIDs);
 
-	/** Get User combined info all inputs are optional except the session ticket.*/
+	/** Retrieves the unique PlayFab identifiers for the given set of Game Center identifiers (referenced in the Game Center Programming Guide as the Player Identifier) */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+		static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromGameCenterIDs(FString SessionTicket, TArray<FString> GameCenterIDs);
+
+	/** Retrieves the unique PlayFab identifiers for the given set of PlayStation Network identifiers */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+		static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromPSNAccountIDs(FString SessionTicket, TArray<FString> PSNAccountIDs);
+
+	/** Retrieves the unique PlayFab identifiers for the given set of Steam identifiers. The Steam identifiers are the profile IDs for the user accounts, available as SteamId in 
+	the Steamworks Community API calls */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+		static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromSteamIDs(FString SessionTicket, TArray<FString> SteamIDs);
+
+	/** Retrieves all requested data for a user in one unified request. By default, this API returns all data for the locally signed-in user. The input parameters may be used to 
+	limit the data retrieved any any subset of the available data, as well as retrieve the available data for a different user. Note that certain data, including inventory, virtual 
+	currency balances, and personally identifying information, may only be retrieved for the locally signed-in user. In the example below, a request is made for the account details, 
+	virtual currency balances, and specified user data for the locally signed-in user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 		static UVaRestPlayFabManager* ConstructGetUserCombinedInfo(FString SessionTicket, TArray<FString> UserDataKeys, 
 		TArray<FString> ReadOnlyDataKey, FString PlayFabId = "", FString Username = "",
 		FString Email = "", FString TitleDisplayName = "", bool GetAccountInfo = false, bool GetInventory = true, bool GetVirtualCurrency = true, 
 		bool GetUserData = true, bool GetReadOnlyData = true);
 
-	/** Create Link android device ID */
+	/** Links the Android device identifier to the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId, FString OSVersion = "", FString AndroidDeviceType = "");
 
-	/** Create Link FacebookAccount */
+	/** Links the Facebook account associated with the provided Facebook access token to the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkFacebookAccount(FString SessionTicket, FString FacebookAccessToken);
 
-	/** Create Link GameCenterAccount */
+	/** Links the Game Center account associated with the provided Game Center ID to the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkGameCenterAccount(FString SessionTicket, FString GameCenterId);
 
-	/** Create Link GoogleAccount */
+	/** Links the currently signed-in user account to the Google account specified by the Google account access token  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkGoogleAccount(FString SessionTicket, FString GoogleAccessToken);
 
-	/** Create Link IOS device ID */
+	/** Links the vendor-specific iOS device identifier to the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId, FString OSVersion = "", FString IOSDeviceModel = "");
 
-	/** Create Link SteamAccount */
+	/** Links the Steam account associated with the provided Steam authentication ticket to the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructLinkSteamAccount(FString SessionTicket, FString SteamAccessToken);
 
-	/** Create SendAccountRecoverEmail */
+	/** Forces an email to be sent to the registered email address for the user's account, with a link allowing the user to change the password  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructSendAccountRecoverEmail(FString Email);
 
-	/** Create UnLink android device ID */
+	/** Unlinks the related Android device identifier from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId);
 
-	/** Create UnLink FacebookAccount */
+	/** Unlinks the related Facebook account from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkFacebookAccount(FString SessionTicket);
 
-	/** Create UnLink GameCenterAccount */
+	/** Unlinks the related Game Center account from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkGameCenterAccount(FString SessionTicket);
 
-	/** Create UnLink GoogleAccount */
+	/** Unlinks the related Google account from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkGoogleAccount(FString SessionTicket);
 
-	/** Create UnLink IOS device ID */
+	/** Unlinks the related iOS device identifier from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId);
 
-	/** Create UnLink SteamAccount */
+	/** Unlinks the related Steam account from the user's PlayFab account  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUnlinkSteamAccount(FString SessionTicket);
 
-	/** Create UpdateUserTitleDisplayName */
+	/** Updates the title specific display name for the user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
 	static UVaRestPlayFabManager* ConstructUpdateUserTitleDisplayName(FString SessionTicket, FString DisplayName);
 
 	// Player Data Management
 
-	/** Create GetFriendLeaderboard */
+	/** Retrieves a list of ranked friends of the current player for the given statistic, starting from the indicated point in the leaderboard  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetFriendLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
 
-	/** Create GetLeaderboard */
+	/** Retrieves a list of ranked users for the given statistic, starting from the indicated point in the leaderboard  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
 
-	/** Create GetLeaderboardAroundCurrentUser */
+	/** Retrieves a list of ranked users for the given statistic, centered on the currently signed-in user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetLeaderboardAroundCurrentUser(FString SessionTicket, FString StatisticName, int32 MaxResultsCount);
 
-	/** Get User Data */
+	/** Retrieves the title-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetUserData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
 
-	/** Get User Publisher Data */
+	/** Retrieves the publisher-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetUserPublisherData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
 
-	/** Get User Publisher Read Only Data */
+	/** Retrieves the publisher-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetUserPublisherReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
 
-	/** Get User Read Only Data */
+	/** Retrieves the title-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetUserReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
 
-	/** Get User Statistics */
+	/** Retrieves the details of all title-specific statistics for the user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructGetUserStatistics(FString SessionTicket);
 
-	/** Update User Data */
+	/** Creates and updates the title-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructUpdateUserData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User Publisher Data */
+	/** Creates and updates the publisher-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructUpdateUserPublisherData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User Statistics */
+	/** Updates the values of the specified title-specific statistics for the user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
 	static UVaRestPlayFabManager* ConstructUpdateUserStatistics(FString SessionTicket, UVaRestJsonObject* Statistics);
 
 	// Title-Wide Data Management
 
-	/** Get Catalog Items */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+	/** Retrieves the specified version of the title's catalog of virtual goods, including all defined properties  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructGetCatalogItems(FString SessionTicket, FString CatalogVersion);
 
-	/** Get Store Items */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+	/** Retrieves the set of items defined for the specified store, including all prices defined  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructGetStoreItems(FString SessionTicket, FString StoreId);
 
-	/** Get Title Data */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+	/** Retrieves the key-value store of custom title settings  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructGetTitleData(FString SessionTicket, TArray<FString> Keys);
 
-	/** Get Title News */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+	/** Retrieves the title news feed, as configured in the developer portal */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructGetTitleNews(FString SessionTicket, int32 NumberofEntries);
 
 	// Player Item Management
 
-	/** Add User Virtual Currency */
+	/** Increments the user's balance of the specified virtual currency by the stated amount  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Management")
 		static UVaRestPlayFabManager* ConstructAddUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount);
 
-	/** Consume Item */
+	/** Consume uses of a consumable item. When all uses are consumed, it will be removed from the player's inventory. */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructConsumeItem(FString SessionTicket, FString ItemInstanceId, int32 ConsumeCount);
 
-	/** Get Character Inventory */
+	/** Retrieves the specified character's current inventory of virtual goods  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructGetCharacterInventory(FString SessionTicket, FString PlayFabId, FString CharacterId, FString CatalogVersion = "");
 
-	/** Get User Inventory */
+	/** Retrieves the user's current inventory of virtual goods  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructGetUserInventory(FString SessionTicket);
 
-	/** Redeem Coupon */
+	/** Adds the virtual goods associated with the coupon to the user's inventory  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructRedeemCoupon(FString SessionTicket, FString CouponCode, FString CatalogVersion = "");
 
-	/** Get Report Player */
+	/** Submit a report for another player (due to bad bahavior, etc.), so that customer service representatives for the title can take 
+	action concerning potentially toxic players.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructReportPlayer(FString SessionTicket, FString ReportedId, FString Reason);
 
-	/** Subtract User Virtual Currency */
+	/** Decrements the user's balance of the specified virtual currency by the stated amount  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructSubtractUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount);
 
-	/** Unlock Container Item */
+	/** Unlocks a container item in the user's inventory and consumes a key item of the type indicated by the container item  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructUnlockContainerItem(FString SessionTicket, FString ContainerItemId, FString CatalogVersion = "");
 
-	/** Start Purchase */
+	/** Creates an order for a list of items from the title catalog  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructStartPurchase(FString SessionTicket, UVaRestJsonObject* Items, FString CatalogVersion = "", FString StoreId = "");
 
-	/** Pay For Purchase */
+	/** Selects a payment option for purchase order created via StartPurchase  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructPayForPurchase(FString SessionTicket, FString OrderId, FString ProviderName, FString Currency);
 
-	/** Confirm Purchase */
+	/** Confirms with the payment provider that the purchase was approved (if applicable) and adjusts inventory and virtual currency balances as appropriate  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructConfirmPurchase(FString SessionTicket, FString OrderId);
 
-	/** PurchaseItem */
+	/** Buys a single item with virtual currency. You must specify both the virtual currency to use to purchase, as well as what the client believes the price to be. 
+	This lets the server fail the purchase if the price has changed.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
 		static UVaRestPlayFabManager* ConstructPurchaseItem(FString SessionTicket, FString ItemId, FString VirtualCurrency, int32 Price, FString CatalogVersion = "", FString StoreId = "");
 
 	// Friend List Managaement
 
-	/** Add Friend */
+	/** Adds the PlayFab user, based upon a match against a supplied unique identifier, to the friend list of the local user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
 		static UVaRestPlayFabManager* ConstructAddFriend(FString SessionTicket, FString FriendPlayFabId = "", FString FriendUsername = "",
 			FString FriendEmail = "", FString FriendTitleDisplayName = "");
 
-	/** Get Friends List */
+	/** Retrieves the current friend list for the local user, constrained to users who have PlayFab accounts. Friends from linked accounts (Facebook, Steam) are also included. 
+	You may optionally exclude some linked services' friends.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
 		static UVaRestPlayFabManager* ConstructGetFriendsList(FString SessionTicket, bool IncludeSteamFriends = true, bool IncludeFacebookFriends = true);
 
-	/** Remove Friend */
+	/** Removes a specified user from the friend list of the local user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
 		static UVaRestPlayFabManager* ConstructRemoveFriend(FString SessionTicket, FString FriendPlayFabId);
 
-	/** Set Friend Tags */
+	/** Updates the tag list for a specified user in the friend list of the local user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
 		static UVaRestPlayFabManager* ConstructSetFriendTags(FString SessionTicket, FString FriendPlayFabId, TArray<FString> Tags);
 
 	// IOS-Specific APIs
 
-	/** Register For IOS Push Notifications */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+	/** Registers the iOS device to receive push notifications */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS Specific")
 		static UVaRestPlayFabManager* ConstructRegisterFORIOSPushNotifications(FString SessionTicket, FString DeviceToken, bool SendPushNotificationConfirmation = false, FString ConfirmationMessage = "");
 
-	/** Restore IOS Purchases */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+	/** Restores all in-app purchases based on the given refresh receipt.  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS Specific")
 		static UVaRestPlayFabManager* ConstructRestoreIOSPurchases(FString SessionTicket, FString Base64ReceiptData);
 
-	/** Validate IOS Reciept */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+	/** Validates with the Apple store that the receipt for an iOS in-app purchase is valid and that it matches the purchased catalog item */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS Specific")
 		static UVaRestPlayFabManager* ConstructValidateIOSReceipt(FString SessionTicket, FString Base64ReceiptData, FString CurrencyCode, FString PurchasePrice);
 
 	// Matchmaking APIs
 
-	/** Get Current Games */
+	/** Get details about all current running game servers matching the given parameters.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
 		static UVaRestPlayFabManager* ConstructGetCurrentGames(FString SessionTicket, ERegion::Type Region, FString BuildVersion = "", FString GameMode = "", FString StatisticName = "");
 
-	/** Get Game Server Regions */
+	/** Get details about the regions hosting game servers matching the given parameters.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
 		static UVaRestPlayFabManager* ConstructGetGameServerRegions(FString SessionTicket, FString BuildVersion);
 
-	/** Matchmake */
+	/** Attempts to locate a game session matching the given parameters. Note that parameters specified in the search are required (they are not weighting factors). 
+	If a slot is found in a server instance matching the parameters, the slot will be assigned to that player, removing it from the availabe set. In that case, the 
+	information on the game session will be returned, otherwise the Status returned will be GameNotFound. Note that EnableQueue is deprecated at this time.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
 		static UVaRestPlayFabManager* ConstructMatchmake(FString SessionTicket, ERegion::Type Region, FString BuildVersion = "", FString GameMode = "", 
 			FString LobbyId = "", FString StatisticName = "", FString CharacterId = "");
 
-	/** Start Game */
+	/** Start a new game server with a given configuration, add the current player and return the connection information.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
 		static UVaRestPlayFabManager* ConstructStartGame(FString SessionTicket, FString BuildVersion, ERegion::Type Region, FString GameMode, FString StatisticName = "",
 			FString CharacterId = "", bool PasswordRestricted = false, FString CustomCommandLineData = "");
 
 	// Android-Specific APIs
 
-	/** Android Device Push Notification Registration */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android-Specific")
+	/** Registers the Android device to receive push notifications  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android Specific")
 		static UVaRestPlayFabManager* ConstructAndroidDevicePushNotificationRegistration(FString SessionTicket, FString DeviceToken, bool SendPushNotificationConfirmation = false, 
 			FString ConfirmationMessage = "");
 
-	/** Validate Google Play Purchase */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android-Specific")
+	/** Validates a Google Play purchase and gives the corresponding item to the player.  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android Specific")
 		static UVaRestPlayFabManager* ConstructValidateGooglePlayPurchase(FString SessionTicket, FString ReceiptJsonString, FString Signature);
 
 	// Analytics
 
-	/** Log Event */
+	/** Logs a custom analytics event  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Analytics")
 		static UVaRestPlayFabManager* ConstructLogEvent(FString SessionTicket, FString EventName, UVaRestJsonObject* Body, bool ProfileSetEvent = false);
 
 	// Shared Group Data
 
-	/** Add Shared Group Memebers */
+	/** Adds users to the set of those able to update both the shared data, as well as the set of users in the group. Only users in the group can add new members.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructAddSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds);
 
-	/** Create Shared Group */
+	/** Requests the creation of a shared group object, containing key/value pairs which may be updated by all members of the group. Upon creation, 
+	the current user will be the only member of the group.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructCreateSharedGroup(FString SessionTicket, FString SharedGroupId);
 
-	/** Get Publisher Data */
+	/** Retrieves the key-value store of custom publisher settings  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructGetPublisherData(FString SessionTicket, TArray<FString> Keys);
 
-	/** Get Shared Group Data */
+	/** Retrieves data stored in a shared group object, as well as the list of members in the group. Non-members of the group may use this to retrieve group data, 
+	including membership, but they will not receive data for keys marked as private.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructGetSharedGroupData(FString SessionTicket, FString SharedGroupId, TArray<FString> Keys, bool GetMembers = true);
 
-	/** Remove Shared Group Memebers */
+	/** Removes users from the set of those able to update the shared data and the set of users in the group. Only users in the group can remove members. 
+	If as a result of the call, zero users remain with access, the group and its associated data will be deleted.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructRemoveSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds);
 
-	/** Update Shared Group Data */
+	/** Adds, updates, and removes data keys for a shared group object. If the permission is set to Public, all fields updated or added in this call will be readable 
+	by users not in the group. By default, data permissions are set to Private. Regardless of the permission setting, only members of the group can update the data.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructUpdateSharedGroupData(FString SessionTicket, FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 
 	// Sony Specific APIs
 	
-	/** RefreshPSNAuthToken */
+	/** Uses the supplied OAuth code to refresh the internally cached player PSN auth token  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Sony Specific")
 		static UVaRestPlayFabManager* ConstructRefreshPSNAuthToken(FString SessionTicket, FString PSNAuthCode);
 
 	// Server-Side Cloud Script
 
-	/** Get Cloud Script Url */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server-Side Cloud Script")
+	/** Retrieves the title-specific URL for Cloud Script servers. This must be queried once, prior to making any calls to RunCloudScript. */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server Side Cloud Script")
 		static UVaRestPlayFabManager* ConstructGetCloudScriptUrl(FString SessionTicket, int32 Version, bool Testing);
 
-	/** Run Cloud Script */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server-Side Cloud Script")
+	/** Triggers a particular server action, passing the provided inputs to the hosted Cloud Script. An action in this context is a handler in the JavaScript. NOTE: Before calling this API, 
+	you must call GetCloudScriptUrl to be assigned a Cloud Script server URL. When using an official PlayFab SDK, this URL is stored internally in the SDK, but GetCloudScriptUrl must still be manually called.  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server Side Cloud Script")
 		static UVaRestPlayFabManager* ConstructRunCloudScript(FString SessionTicket, FString ActionId, UVaRestJsonObject* Params, FString ParamsEncoded = "");
 
 	// Content
 
-	/** Get Content Download Url */
+	/** Retrieves the pre-authorized URL for accessing a content file for the title. A subsequent HTTP GET to the returned URL downloads the content; or a HEAD query to the returned URL retrieves 
+	the metadata of the content. This API only generates a pre-signed URL to access the content. A success result does not guarantee the existence of the content.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Content")
 		static UVaRestPlayFabManager* ConstructGetContentDownloadUrl(FString SessionTicket, FString Key, FString HttpMethod = "", bool ThruCDN = true);
 
 	// Characters
 
-	/** Get Character Leaderboard */
+	/** Retrieves a list of ranked characters for the given statistic, starting from the indicated point in the leaderboard  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
 		static UVaRestPlayFabManager* ConstructGetCharacterLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, 
 			FString CharacterType = "", int32 StartPosition = 0);
 
-	/** Get Leaderboard Around Character */
+	/** Retrieves a list of ranked characters for the given statistic, centered on the currently signed-in user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
 		static UVaRestPlayFabManager* ConstructGetLeaderboardAroundCharacter(FString SessionTicket, FString CharacterId, FString StatisticName, int32 MaxResultsCount,
 		FString CharacterType = "");
 
-	/** Get Leaderboard For User Character */
+	/** Retrieves a list of all of the user's characters for the given statistic.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
 		static UVaRestPlayFabManager* ConstructGetLeaderboardForUserCharacters(FString SessionTicket, FString StatisticName, int32 MaxResultsCount);
 
-	/** Grant Character To User */
+	/** Grants the specified character type to the user.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
 		static UVaRestPlayFabManager* ConstructGrantCharacterToUser(FString SessionTicket, FString ItemId, FString CharacterName, FString CatalogVersion = "");
 
 	// Character Data
 
-	/** Get Character Data */
+	/** Retrieves the title-specific custom data for the character which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
 		static UVaRestPlayFabManager* ConstructGetCharacterData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys);
 
-	/** Get Character ReadOnly Data */
+	/** Retrieves the title-specific custom data for the character which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
 		static UVaRestPlayFabManager* ConstructGetCharacterReadOnlyData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys);
 
-	/** Update Character Data */
+	/** Creates and updates the title-specific custom data for the user's character which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
 		static UVaRestPlayFabManager* ConstructUpdateCharacterData(FString SessionTicket, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 
@@ -448,307 +475,335 @@ class UVaRestPlayFabManager : public UVaRestRequestJSON
 
 	// Authentication
 
-	/** Create Json object that contains authentication request object */
+	/** Validated a client's session ticket, and if successful, returns details for that user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Authentication")
 	static UVaRestPlayFabManager* ConstructAuthenticateSessionTicket(FString SessionTicket);
 
 	// Account Management
 
-	/** Get User Account Info */
+	/** Retrieves the relevant details for a specified user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Account Management")
 		static UVaRestPlayFabManager* ConstructGetUserAccountInfo(FString PlayFabId);
 
-	/** Send Push Notification */
+	/** Sends an iOS/Android Push Notification to a specific user, if that user's device has 
+	been configured for Push Notifications in PlayFab. If a user has linked both Android and iOS devices, both will be notified.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Account Management")
 		static UVaRestPlayFabManager* ConstructSendPushNotification(FString RecipientPlayFabId, FString Message, FString Subject = "");
 
 	// Player Data Management
 
-	/** Create GetLeaderboard */
+	/** Retrieves a list of ranked users for the given statistic, starting from the indicated point in the leaderboard  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetLeaderboard(FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
 
-	/** Create GetLeaderboardAroundUser */
+	/** Retrieves a list of ranked users for the given statistic, centered on the currently signed-in user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructGetLeaderboardAroundUser(FString StatisticName, FString PlayFabId, int32 MaxResultsCount);
 
-	/** Get User Data */
+	/** Retrieves the title-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Internal Data */
+	/** Retrieves the title-specific custom data for the user which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserInternalData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Publisher Data */
+	/** Retrieves the publisher-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserPublisherData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Publisher Data */
+	/** Retrieves the publisher-specific custom data for the user which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserPublisherInternalData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Publisher Read Only Data */
+	/** Retrieves the publisher-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserPublisherReadOnlyData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Read Only Data */
+	/** Retrieves the title-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserReadOnlyData(TArray<FString> Keys, FString PlayFabId);
 
-	/** Get User Statistics */
+	/** Retrieves the details of all title-specific statistics for the user */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserStatistics(FString PlayFabId);
 
-	/** Update User Data */
+	/** Updates the title-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User Internal Data */
+	/** Updates the title-specific custom data for the user which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserInternalData(FString PlayFabId, UVaRestJsonObject* Data);
 
-	/** Update User Publisher Data */
+	/** Updates the publisher-specific custom data for the user which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User Publisher Internal Data */
+	/** Updates the publisher-specific custom data for the user which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherInternalData(FString PlayFabId, UVaRestJsonObject* Data);
 
-	/** Update User Publisher ReadOnly Data */
+	/** Updates the publisher-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User ReadOnly Data */
+	/** Updates the title-specific custom data for the user which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
 
-	/** Update User Statistics */
+	/** Updates the values of the specified title-specific statistics for the user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserStatistics(FString PlayFabId, UVaRestJsonObject* Statistics);
 
 	// Title-Wide Data Management
 
-	/** Get Catalog Items */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+	/** Retrieves the specified version of the title's catalog of virtual goods, including all defined properties  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetCatalogItems(FString CatalogVersion);
 
-	/** Get Title Data */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+	/** Retrieves the key-value store of custom title settings  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetTitleData(TArray<FString> Keys);
 
-	/** Get Title Internal Data */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+	/** Retrieves the key-value store of custom internal title settings  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructServerGetTitleInternalData(TArray<FString> Keys);
 
-	/** Set Title Data */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+	/** Updates the key-value store of custom title settings  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructServerSetTitleData(FString Key, FString Value);
 
-	/** Get Title nternal Data */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+	/** Updates the key-value store of custom title settings  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title Wide Data Management")
 		static UVaRestPlayFabManager* ConstructServerSetTitleInternalData(FString Key, FString Value);
 
 	// Player Item Management
 
-	/** Add Character Virtual Currency */
+	/** Increments the character's balance of the specified virtual currency by the stated amount  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerAddCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount);
 
-	/** Add User Virtual Currency */
+	/** Increments the user's balance of the specified virtual currency by the stated amount */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerAddUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount);
 
-	/** Get Character Inventory */
+	/** Retrieves the specified character's current inventory of virtual goods  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterInventory(FString PlayFabId, FString CharacterId, FString CatalogVersion = "");
 
-	/** Get User Inventory */
+	/** Retrieves the specified user's current inventory of virtual goods  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerGetUserInventory(FString PlayFabId, FString CatalogVersion = "");
 
-	/** Grant Items To Character */
+	/** Adds the specified items to the specified character's inventory */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerGrantItemsToCharacter(FString PlayFabId, FString CharacterId, TArray<FString> ItemIds, FString CatalogVersion = "", 
 		FString Annotation = "");
 
-	/** Grant Items To User */
+	/** Adds the specified items to the specified user's inventory  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerGrantItemsToUser(FString PlayFabId, TArray<FString> ItemIds, FString CatalogVersion = "",
 		FString Annotation = "");
 
-	/** Grant Items To Users */
+	/** Adds the specified items to the specified user inventories  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerGrantItemsToUsers(UVaRestJsonObject* ItemGrants, FString CatalogVersion = "");
 
-	/** Modify Item Uses */
+	/** Modifies the number of remaining uses of a player's inventory item  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerModifyItemUses(FString PlayFabId, FString ItemInstanceId, int32 UsesToAdd);
 
-	/** Move Item To Character From Character */
+	/** Moves an item from a character's inventory into another of the users's character's inventory.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerMoveItemToCharacterFromCharacter(FString PlayFabId, FString GivingCharacterId, 
 			FString ReceivingCharacterId, FString ItemInstanceId);
 
-	/** Move Item To Character From User */
+	/** Moves an item from a user's inventory into their character's inventory. */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerMoveItemToCharacterFromUser(FString PlayFabId, FString CharacterId,
 		FString ItemInstanceId);
 
-	/** Move Item To User From Character */
+	/** Moves an item from a character's inventory into the owning user's inventory.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerMoveItemToUserFromCharacter(FString PlayFabId, FString CharacterId,
 		FString ItemInstanceId);
 
-	/** Report Player */
+	/** Submit a report about a player (due to bad bahavior, etc.) on behalf of another player, so that customer service 
+	representatives for the title can take action concerning potentially poxic players */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerReportPlayer(FString ReporterPlayFabId, FString ReporteePlayFabId, 
 			FString TitleId = "", FString Comment = "");
 
-	/** Subtract Character Virtual Currency */
+	/** Decrements the character's balance of the specified virtual currency by the stated amount */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerSubtractCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount);
 
-	/** Subtract User Virtual Currency */
+	/** Decrements the user's balance of the specified virtual currency by the stated amount  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerSubtractUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount);
 
-	/** Update User Inventory Item Custom Data */
+	/** Updates the key-value pair data tagged to the specified item, which is read-only from the client.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
 		static UVaRestPlayFabManager* ConstructServerUpdateUserInventoryItemCustomData(FString PlayFabId, FString ItemInstanceId, 
 			UVaRestJsonObject* Data, FString CharacterId = "");
 	
 	// Matchmaking
 
-	/** Notify Matchmaker Player Left */
+	/** Informs the PlayFab match-making service that the user specified has left the Game Server Instance  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Matchmaking")
 		static UVaRestPlayFabManager* ConstructServerNotifyMatchmakerPlayerLeft(FString PlayFabId, FString LobbyId);
 
-	/** Redeem Matchmaker Ticket */
+	/** Validates a Game Server session ticket and returns details about the user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Matchmaking")
 		static UVaRestPlayFabManager* ConstructServerRedeemMatchmakerTicket(FString Ticket, FString LobbyId);
 
 	// Steam-Specific
 
-	/** Award Steam Achievement */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Steam-Specific")
+	/** Awards the specified users the specified Steam achievements  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Steam Specific")
 		static UVaRestPlayFabManager* ConstructServerAwardSteamAchievement(UVaRestJsonObject* Achievements);
 
 	// Analytics
 
-	/** Log Event */
+	/** Logs a custom analytics event  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Analytics")
 		static UVaRestPlayFabManager* ConstructServerLogEvent(FString EventName, UVaRestJsonObject* Body, FString PlayFabId = "", 
 			FString EntityId = "", FString EntityType = "", bool PlayerEvent = true, bool ProfileSetEvent = false);
 
 	// Shared Group Data
 
-	/** Add Shared Group Memebers */
+	/** Adds users to the set of those able to update both the shared data, as well as the set of users in the group. 
+	Only users in the group (and the server) can add new members.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerAddSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds);
 
-	/** Create Shared Group */
+	/** Requests the creation of a shared group object, containing key/value pairs which may be updated by all members of 
+	the group. When created by a server, the group will initially have no members.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerCreateSharedGroup(FString SharedGroupId);
 
-	/** Delete Shared Group */
+	/** Deletes a shared group, freeing up the shared group ID to be reused for a new group */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerDeleteSharedGroup(FString SharedGroupId);
 
-	/** Get Publisher Data */
+	/** Retrieves the key-value store of custom publisher settings */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerGetPublisherData(TArray<FString> Keys);
 
-	/** Get Shared Group Data */
+	/** Retrieves data stored in a shared group object, as well as the list of members in the group. 
+	The server can access all public and private group data.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerGetSharedGroupData(FString SharedGroupId, TArray<FString> Keys, bool GetMembers = true);
 
-	/** Remove Shared Group Memebers */
+	/** Removes users from the set of those able to update the shared data and the set of users in the group. Only users in the group can remove members. 
+	If as a result of the call, zero users remain with access, the group and its associated data will be deleted.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerRemoveSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds);
 
-	/** Set Publisher Data */
+	/** Updates the key-value store of custom publisher settings  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerSetPublisherData(FString Key, FString Value);
 
-	/** Update Shared Group Data */
+	/** Adds, updates, and removes data keys for a shared group object. If the permission is set to Public, all fields updated or added in this call will be readable 
+	by users not in the group. By default, data permissions are set to Private. Regardless of the permission setting, only members of the group (and the server) can 
+	update the data. */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
 		static UVaRestPlayFabManager* ConstructServerUpdateSharedGroupData(FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 	
 	// Content
 
-	/** Get Content Download Url */
+	/** Retrieves the pre-authorized URL for accessing a content file for the title. A subsequent HTTP GET to the returned URL downloads the content; or a HEAD 
+	query to the returned URL retrieves the metadata of the content. This API only generates a pre-signed URL to access the content. A success result does not 
+	guarantee the existence of the content.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Content")
 		static UVaRestPlayFabManager* ConstructServerGetContentDownloadUrl(FString Key, FString HttpMethod = "", bool ThruCDN = true);
 
 	// Characters
 
-	/** Delete Character From User */
+	/** Deletes the specific character ID from the specified user.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerDeleteCharacterFromUser(FString PlayFabId, FString CharacterId, bool SaveCharacterInventory = false);
 
-	/** Get All Users Characters */
+	/** Lists all of the characters that belong to a specific user. */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGetAllUsersCharacters(FString PlayFabId);
 
-	/** Get Character Leaderboard */
+	/** Retrieves a list of ranked characters for the given statistic, starting from the indicated point in the leaderboard  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterLeaderboard(FString CharacterId, FString StatisticName, int32 MaxResultsCount,
 		FString CharacterType = "", int32 StartPosition = 0);
 
-	/** Get Character Statistics */
+	/** Retrieves the details of all title-specific statistics for the specific character */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterStatistics(FString PlayFabId, FString CharacterId);
 
-	/** Get Leaderboard Around Character */
+	/** Retrieves a list of ranked characters for the given statistic, centered on the requested user  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGetLeaderboardAroundCharacter(FString PlayFabId, FString CharacterId, FString StatisticName, int32 MaxResultsCount,
 		FString CharacterType = "");
 
-	/** Get Leaderboard For User Character */
+	/** Retrieves a list of all of the user's characters for the given statistic.  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGetLeaderboardForUserCharacters(FString PlayFabId, FString StatisticName, int32 MaxResultsCount);
 
-	/** Grant Character To User */
+	/** Grants the specified character type to the user. */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerGrantCharacterToUser(FString PlayFabId, FString CharacterType, FString CharacterName);
 
-	/** Update Character Statistics */
+	/** Updates the values of the specified title-specific statistics for the specific character  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
 		static UVaRestPlayFabManager* ConstructServerUpdateCharacterStatistics(FString PlayFabId, FString CharacterId, UVaRestJsonObject* CharacterStatistics);
 
 	// Character Data
 
-	/** Get Character Data */
+	/** Retrieves the title-specific custom data for the user which is readable and writable by the client */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
 
-	/** Get Character Internal Data */
+	/** Retrieves the title-specific custom data for the user's character which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterInternalData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
 
-	/** Get Character ReadOnly Data */
+	/** Retrieves the title-specific custom data for the user's character which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerGetCharacterReadOnlyData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
 
-	/** Update Character Data */
+	/** Updates the title-specific custom data for the user's chjaracter which is readable and writable by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerUpdateCharacterData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 
-	/** Update Character Internal Data */
+	/** Updates the title-specific custom data for the user's character which cannot be accessed by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerUpdateCharacterInternalData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 
-	/** Update Character ReadOnly Data */
+	/** Updates the title-specific custom data for the user's character which can only be read by the client  */
 	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
 		static UVaRestPlayFabManager* ConstructServerUpdateCharacterReadOnlyData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
 
-	// Admin
+	/// Admin
 
-	/** Create Json object that contains current version request request object */
-	UFUNCTION(BlueprintPure, Category = "PlayFab | Admin | CloudScript")
+	// Account Management
+
+	// Player Data Management
+
+	// Title-Wide Management
+
+	// Player Item Management
+
+	// Matchmaking
+
+	// Custom Server Management
+
+	// Shared Group Data
+
+	// Server-Side Cloud Script
+
+	/** Gets the contents and information of a specific Cloud Script revision.  */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Admin | Server Side Cloud Script")
 	static UVaRestPlayFabManager* ConstructGetCloudScriptRevision(FString Version, FString Revision);
+
+	// Content
 
 	/** PlayFab Request Info */
 	FString PlayFabClass;

--- a/Source/VaRestPlugin/Classes/PlayFab/VaRestPlayFabManager.h
+++ b/Source/VaRestPlugin/Classes/PlayFab/VaRestPlayFabManager.h
@@ -1,0 +1,781 @@
+// Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
+// Update to work with PlayFab 2015 Joshua Lyons
+
+#pragma once
+
+#include "VaRestPlayFabManager.generated.h"
+
+// Enum for the UserDataPermission
+UENUM(BlueprintType)
+namespace EUserDataPermision
+{
+	enum Type
+	{
+		PRIVATE,
+		PUBLIC
+	};
+}
+
+// Enum for Region
+UENUM(BlueprintType)
+namespace ERegion
+{
+	enum Type
+	{
+		ANY,
+		USCENTRAL,
+		USEAST,
+		EUWEST,
+		SINGAPORE,
+		JAPAN,
+		BRAZIL,
+		AUSTRALIA
+	};
+}
+
+/**
+ * Helper class to make PlayFab communication easier
+ */
+UCLASS(BlueprintType, Blueprintable)
+class UVaRestPlayFabManager : public UVaRestRequestJSON
+{
+	GENERATED_UCLASS_BODY()
+
+	/** Creates new PlayFab request with defined verb and content type */
+	UFUNCTION(BlueprintPure, meta = (DisplayName = "Construct PlayFab Request", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"), Category = "VaRest|PlayFab")
+	static UVaRestPlayFabManager* ConstructPlayFabRequest(UObject* WorldContextObject, ERequestVerb::Type Verb, ERequestContentType::Type ContentType);
+
+	void ProcessPlayFabURL(const FString& PlayFabClass = "", const FString& PlayFabSessionToken = "", bool isAdmin = false,
+		bool isServer = false, bool isClient = false, bool useSecretKey = false, bool useSessionTicket = false,
+		bool cloudScript = false, FString cloudScriptVersion = "");
+
+	// This will process the PlayFab Request
+	UFUNCTION(BlueprintCallable, Category = "VaRest|PlayFab")
+	void ProcessPlayFabRequest();
+
+	/** Set PlayFab authenication data */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|PlayFab")
+	static void SetPlayFabAuthData(FString AppId, FString ApiKey);
+
+	//////////////////////////////////////////////////////////////////////////
+	// Play Fab Construction Helpers
+	//////////////////////////////////////////////////////////////////////////
+
+	//// Client
+
+	// Authentication
+
+	/** Create Json object that contains play fab login data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithPlayFab(FString Username, FString Password);
+
+	/** Create Json object that contains play fab login data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructRegisterWithPlayFab(FString Username, FString Password, FString Email);
+
+	/** Create Get Photon Authentication Toeken Request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructGetPhotonAuthenticationToken(FString SessionTicket, bool PhotonRealtime, bool PhotonTurnbased, bool PhotonChat);
+
+	/** Create a Login with Android Device Request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithAndroidDeviceID(FString AndroidDeviceId, FString OSVersion = "", FString AndroidDeviceType = "", bool CreateAccount = false);
+
+	/** Create Login with email request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithEmail(FString Username, FString Password);
+
+	/** Create a Login with Facebook request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithFacebook(FString FacebookAccessToken, bool CreateAccount = false);
+
+	/** Create a Login with Google request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithGoogle(FString GoogleAccessToken, bool CreateAccount = false);
+
+	/** Create a Login with IOS Device Request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithIOSDeviceID(FString IOSDeviceId, FString OSVersion = "", FString DeviceModel = "", bool CreateAccount = false);
+
+	/** Create a Login with Steam request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Authentication")
+	static UVaRestPlayFabManager* ConstructLoginWithSteam(FString SteamAccessToken, bool CreateAccount = false);
+
+	// Account Management
+
+	/** Add Username Password Request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructAddUsernamePassword(FString SessionTicket, FString Email, FString Username, FString Password);
+
+	/** Get Account Info Request */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructGetAccountInfo(FString SessionTicket, FString PlayFabId, FString Username = "", FString Email = "", FString TitleDisplayName = "");
+	
+	/** Get Play Fab Ids from Facebook Ids */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructGetPlayFabIDsFromFacebookIDs(FString SessionTicket, TArray<FString> FacebookIDs);
+
+	/** Get User combined info all inputs are optional except the session ticket.*/
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+		static UVaRestPlayFabManager* ConstructGetUserCombinedInfo(FString SessionTicket, TArray<FString> UserDataKeys, 
+		TArray<FString> ReadOnlyDataKey, FString PlayFabId = "", FString Username = "",
+		FString Email = "", FString TitleDisplayName = "", bool GetAccountInfo = false, bool GetInventory = true, bool GetVirtualCurrency = true, 
+		bool GetUserData = true, bool GetReadOnlyData = true);
+
+	/** Create Link android device ID */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId, FString OSVersion = "", FString AndroidDeviceType = "");
+
+	/** Create Link FacebookAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkFacebookAccount(FString SessionTicket, FString FacebookAccessToken);
+
+	/** Create Link GameCenterAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkGameCenterAccount(FString SessionTicket, FString GameCenterId);
+
+	/** Create Link GoogleAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkGoogleAccount(FString SessionTicket, FString GoogleAccessToken);
+
+	/** Create Link IOS device ID */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId, FString OSVersion = "", FString IOSDeviceModel = "");
+
+	/** Create Link SteamAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructLinkSteamAccount(FString SessionTicket, FString SteamAccessToken);
+
+	/** Create SendAccountRecoverEmail */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructSendAccountRecoverEmail(FString Email);
+
+	/** Create UnLink android device ID */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId);
+
+	/** Create UnLink FacebookAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkFacebookAccount(FString SessionTicket);
+
+	/** Create UnLink GameCenterAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkGameCenterAccount(FString SessionTicket);
+
+	/** Create UnLink GoogleAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkGoogleAccount(FString SessionTicket);
+
+	/** Create UnLink IOS device ID */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId);
+
+	/** Create UnLink SteamAccount */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUnlinkSteamAccount(FString SessionTicket);
+
+	/** Create UpdateUserTitleDisplayName */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Account Management")
+	static UVaRestPlayFabManager* ConstructUpdateUserTitleDisplayName(FString SessionTicket, FString DisplayName);
+
+	// Player Data Management
+
+	/** Create GetFriendLeaderboard */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetFriendLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
+
+	/** Create GetLeaderboard */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
+
+	/** Create GetLeaderboardAroundCurrentUser */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetLeaderboardAroundCurrentUser(FString SessionTicket, FString StatisticName, int32 MaxResultsCount);
+
+	/** Get User Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetUserData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
+
+	/** Get User Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetUserPublisherData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
+
+	/** Get User Publisher Read Only Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetUserPublisherReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
+
+	/** Get User Read Only Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetUserReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId = "");
+
+	/** Get User Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructGetUserStatistics(FString SessionTicket);
+
+	/** Update User Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructUpdateUserData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructUpdateUserPublisherData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Data Management")
+	static UVaRestPlayFabManager* ConstructUpdateUserStatistics(FString SessionTicket, UVaRestJsonObject* Statistics);
+
+	// Title-Wide Data Management
+
+	/** Get Catalog Items */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructGetCatalogItems(FString SessionTicket, FString CatalogVersion);
+
+	/** Get Store Items */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructGetStoreItems(FString SessionTicket, FString StoreId);
+
+	/** Get Title Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructGetTitleData(FString SessionTicket, TArray<FString> Keys);
+
+	/** Get Title News */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructGetTitleNews(FString SessionTicket, int32 NumberofEntries);
+
+	// Player Item Management
+
+	/** Add User Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Management")
+		static UVaRestPlayFabManager* ConstructAddUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount);
+
+	/** Consume Item */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructConsumeItem(FString SessionTicket, FString ItemInstanceId, int32 ConsumeCount);
+
+	/** Get Character Inventory */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructGetCharacterInventory(FString SessionTicket, FString PlayFabId, FString CharacterId, FString CatalogVersion = "");
+
+	/** Get User Inventory */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructGetUserInventory(FString SessionTicket);
+
+	/** Redeem Coupon */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructRedeemCoupon(FString SessionTicket, FString CouponCode, FString CatalogVersion = "");
+
+	/** Get Report Player */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructReportPlayer(FString SessionTicket, FString ReportedId, FString Reason);
+
+	/** Subtract User Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructSubtractUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount);
+
+	/** Unlock Container Item */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructUnlockContainerItem(FString SessionTicket, FString ContainerItemId, FString CatalogVersion = "");
+
+	/** Start Purchase */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructStartPurchase(FString SessionTicket, UVaRestJsonObject* Items, FString CatalogVersion = "", FString StoreId = "");
+
+	/** Pay For Purchase */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructPayForPurchase(FString SessionTicket, FString OrderId, FString ProviderName, FString Currency);
+
+	/** Confirm Purchase */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructConfirmPurchase(FString SessionTicket, FString OrderId);
+
+	/** PurchaseItem */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Player Item Data Management")
+		static UVaRestPlayFabManager* ConstructPurchaseItem(FString SessionTicket, FString ItemId, FString VirtualCurrency, int32 Price, FString CatalogVersion = "", FString StoreId = "");
+
+	// Friend List Managaement
+
+	/** Add Friend */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
+		static UVaRestPlayFabManager* ConstructAddFriend(FString SessionTicket, FString FriendPlayFabId = "", FString FriendUsername = "",
+			FString FriendEmail = "", FString FriendTitleDisplayName = "");
+
+	/** Get Friends List */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
+		static UVaRestPlayFabManager* ConstructGetFriendsList(FString SessionTicket, bool IncludeSteamFriends = true, bool IncludeFacebookFriends = true);
+
+	/** Remove Friend */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
+		static UVaRestPlayFabManager* ConstructRemoveFriend(FString SessionTicket, FString FriendPlayFabId);
+
+	/** Set Friend Tags */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Friend List Management")
+		static UVaRestPlayFabManager* ConstructSetFriendTags(FString SessionTicket, FString FriendPlayFabId, TArray<FString> Tags);
+
+	// IOS-Specific APIs
+
+	/** Register For IOS Push Notifications */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+		static UVaRestPlayFabManager* ConstructRegisterFORIOSPushNotifications(FString SessionTicket, FString DeviceToken, bool SendPushNotificationConfirmation = false, FString ConfirmationMessage = "");
+
+	/** Restore IOS Purchases */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+		static UVaRestPlayFabManager* ConstructRestoreIOSPurchases(FString SessionTicket, FString Base64ReceiptData);
+
+	/** Validate IOS Reciept */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | IOS-Specific")
+		static UVaRestPlayFabManager* ConstructValidateIOSReceipt(FString SessionTicket, FString Base64ReceiptData, FString CurrencyCode, FString PurchasePrice);
+
+	// Matchmaking APIs
+
+	/** Get Current Games */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
+		static UVaRestPlayFabManager* ConstructGetCurrentGames(FString SessionTicket, ERegion::Type Region, FString BuildVersion = "", FString GameMode = "", FString StatisticName = "");
+
+	/** Get Game Server Regions */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
+		static UVaRestPlayFabManager* ConstructGetGameServerRegions(FString SessionTicket, FString BuildVersion);
+
+	/** Matchmake */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
+		static UVaRestPlayFabManager* ConstructMatchmake(FString SessionTicket, ERegion::Type Region, FString BuildVersion = "", FString GameMode = "", 
+			FString LobbyId = "", FString StatisticName = "", FString CharacterId = "");
+
+	/** Start Game */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Matchmaking")
+		static UVaRestPlayFabManager* ConstructStartGame(FString SessionTicket, FString BuildVersion, ERegion::Type Region, FString GameMode, FString StatisticName = "",
+			FString CharacterId = "", bool PasswordRestricted = false, FString CustomCommandLineData = "");
+
+	// Android-Specific APIs
+
+	/** Android Device Push Notification Registration */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android-Specific")
+		static UVaRestPlayFabManager* ConstructAndroidDevicePushNotificationRegistration(FString SessionTicket, FString DeviceToken, bool SendPushNotificationConfirmation = false, 
+			FString ConfirmationMessage = "");
+
+	/** Validate Google Play Purchase */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Android-Specific")
+		static UVaRestPlayFabManager* ConstructValidateGooglePlayPurchase(FString SessionTicket, FString ReceiptJsonString, FString Signature);
+
+	// Analytics
+
+	/** Log Event */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Analytics")
+		static UVaRestPlayFabManager* ConstructLogEvent(FString SessionTicket, FString EventName, UVaRestJsonObject* Body, bool ProfileSetEvent = false);
+
+	// Shared Group Data
+
+	/** Add Shared Group Memebers */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructAddSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds);
+
+	/** Create Shared Group */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructCreateSharedGroup(FString SessionTicket, FString SharedGroupId);
+
+	/** Get Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructGetPublisherData(FString SessionTicket, TArray<FString> Keys);
+
+	/** Get Shared Group Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructGetSharedGroupData(FString SessionTicket, FString SharedGroupId, TArray<FString> Keys, bool GetMembers = true);
+
+	/** Remove Shared Group Memebers */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructRemoveSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds);
+
+	/** Update Shared Group Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructUpdateSharedGroupData(FString SessionTicket, FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+
+	// Sony Specific APIs
+	
+	/** RefreshPSNAuthToken */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Sony Specific")
+		static UVaRestPlayFabManager* ConstructRefreshPSNAuthToken(FString SessionTicket, FString PSNAuthCode);
+
+	// Server-Side Cloud Script
+
+	/** Get Cloud Script Url */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server-Side Cloud Script")
+		static UVaRestPlayFabManager* ConstructGetCloudScriptUrl(FString SessionTicket, int32 Version, bool Testing);
+
+	/** Run Cloud Script */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Server-Side Cloud Script")
+		static UVaRestPlayFabManager* ConstructRunCloudScript(FString SessionTicket, FString ActionId, UVaRestJsonObject* Params, FString ParamsEncoded = "");
+
+	// Content
+
+	/** Get Content Download Url */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Content")
+		static UVaRestPlayFabManager* ConstructGetContentDownloadUrl(FString SessionTicket, FString Key, FString HttpMethod = "", bool ThruCDN = true);
+
+	// Characters
+
+	/** Get Character Leaderboard */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
+		static UVaRestPlayFabManager* ConstructGetCharacterLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, 
+			FString CharacterType = "", int32 StartPosition = 0);
+
+	/** Get Leaderboard Around Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
+		static UVaRestPlayFabManager* ConstructGetLeaderboardAroundCharacter(FString SessionTicket, FString CharacterId, FString StatisticName, int32 MaxResultsCount,
+		FString CharacterType = "");
+
+	/** Get Leaderboard For User Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
+		static UVaRestPlayFabManager* ConstructGetLeaderboardForUserCharacters(FString SessionTicket, FString StatisticName, int32 MaxResultsCount);
+
+	/** Grant Character To User */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Characters")
+		static UVaRestPlayFabManager* ConstructGrantCharacterToUser(FString SessionTicket, FString ItemId, FString CharacterName, FString CatalogVersion = "");
+
+	// Character Data
+
+	/** Get Character Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
+		static UVaRestPlayFabManager* ConstructGetCharacterData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys);
+
+	/** Get Character ReadOnly Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
+		static UVaRestPlayFabManager* ConstructGetCharacterReadOnlyData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys);
+
+	/** Update Character Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Client | Character Data")
+		static UVaRestPlayFabManager* ConstructUpdateCharacterData(FString SessionTicket, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+
+	/// Server
+
+	// Authentication
+
+	/** Create Json object that contains authentication request object */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Authentication")
+	static UVaRestPlayFabManager* ConstructAuthenticateSessionTicket(FString SessionTicket);
+
+	// Account Management
+
+	/** Get User Account Info */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Account Management")
+		static UVaRestPlayFabManager* ConstructGetUserAccountInfo(FString PlayFabId);
+
+	/** Send Push Notification */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Account Management")
+		static UVaRestPlayFabManager* ConstructSendPushNotification(FString RecipientPlayFabId, FString Message, FString Subject = "");
+
+	// Player Data Management
+
+	/** Create GetLeaderboard */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetLeaderboard(FString StatisticName, int32 MaxResultsCount, int32 StartPosition = 0);
+
+	/** Create GetLeaderboardAroundUser */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructGetLeaderboardAroundUser(FString StatisticName, FString PlayFabId, int32 MaxResultsCount);
+
+	/** Get User Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserInternalData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserPublisherData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserPublisherInternalData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Publisher Read Only Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserPublisherReadOnlyData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Read Only Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserReadOnlyData(TArray<FString> Keys, FString PlayFabId);
+
+	/** Get User Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserStatistics(FString PlayFabId);
+
+	/** Update User Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserInternalData(FString PlayFabId, UVaRestJsonObject* Data);
+
+	/** Update User Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User Publisher Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherInternalData(FString PlayFabId, UVaRestJsonObject* Data);
+
+	/** Update User Publisher ReadOnly Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserPublisherReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User ReadOnly Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType);
+
+	/** Update User Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Data Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserStatistics(FString PlayFabId, UVaRestJsonObject* Statistics);
+
+	// Title-Wide Data Management
+
+	/** Get Catalog Items */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetCatalogItems(FString CatalogVersion);
+
+	/** Get Title Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetTitleData(TArray<FString> Keys);
+
+	/** Get Title Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructServerGetTitleInternalData(TArray<FString> Keys);
+
+	/** Set Title Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructServerSetTitleData(FString Key, FString Value);
+
+	/** Get Title nternal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Title-Wide Data Management")
+		static UVaRestPlayFabManager* ConstructServerSetTitleInternalData(FString Key, FString Value);
+
+	// Player Item Management
+
+	/** Add Character Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerAddCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount);
+
+	/** Add User Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerAddUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount);
+
+	/** Get Character Inventory */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterInventory(FString PlayFabId, FString CharacterId, FString CatalogVersion = "");
+
+	/** Get User Inventory */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerGetUserInventory(FString PlayFabId, FString CatalogVersion = "");
+
+	/** Grant Items To Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerGrantItemsToCharacter(FString PlayFabId, FString CharacterId, TArray<FString> ItemIds, FString CatalogVersion = "", 
+		FString Annotation = "");
+
+	/** Grant Items To User */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerGrantItemsToUser(FString PlayFabId, TArray<FString> ItemIds, FString CatalogVersion = "",
+		FString Annotation = "");
+
+	/** Grant Items To Users */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerGrantItemsToUsers(UVaRestJsonObject* ItemGrants, FString CatalogVersion = "");
+
+	/** Modify Item Uses */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerModifyItemUses(FString PlayFabId, FString ItemInstanceId, int32 UsesToAdd);
+
+	/** Move Item To Character From Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerMoveItemToCharacterFromCharacter(FString PlayFabId, FString GivingCharacterId, 
+			FString ReceivingCharacterId, FString ItemInstanceId);
+
+	/** Move Item To Character From User */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerMoveItemToCharacterFromUser(FString PlayFabId, FString CharacterId,
+		FString ItemInstanceId);
+
+	/** Move Item To User From Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerMoveItemToUserFromCharacter(FString PlayFabId, FString CharacterId,
+		FString ItemInstanceId);
+
+	/** Report Player */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerReportPlayer(FString ReporterPlayFabId, FString ReporteePlayFabId, 
+			FString TitleId = "", FString Comment = "");
+
+	/** Subtract Character Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerSubtractCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount);
+
+	/** Subtract User Virtual Currency */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerSubtractUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount);
+
+	/** Update User Inventory Item Custom Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Player Item Management")
+		static UVaRestPlayFabManager* ConstructServerUpdateUserInventoryItemCustomData(FString PlayFabId, FString ItemInstanceId, 
+			UVaRestJsonObject* Data, FString CharacterId = "");
+	
+	// Matchmaking
+
+	/** Notify Matchmaker Player Left */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Matchmaking")
+		static UVaRestPlayFabManager* ConstructServerNotifyMatchmakerPlayerLeft(FString PlayFabId, FString LobbyId);
+
+	/** Redeem Matchmaker Ticket */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Matchmaking")
+		static UVaRestPlayFabManager* ConstructServerRedeemMatchmakerTicket(FString Ticket, FString LobbyId);
+
+	// Steam-Specific
+
+	/** Award Steam Achievement */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Steam-Specific")
+		static UVaRestPlayFabManager* ConstructServerAwardSteamAchievement(UVaRestJsonObject* Achievements);
+
+	// Analytics
+
+	/** Log Event */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Analytics")
+		static UVaRestPlayFabManager* ConstructServerLogEvent(FString EventName, UVaRestJsonObject* Body, FString PlayFabId = "", 
+			FString EntityId = "", FString EntityType = "", bool PlayerEvent = true, bool ProfileSetEvent = false);
+
+	// Shared Group Data
+
+	/** Add Shared Group Memebers */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerAddSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds);
+
+	/** Create Shared Group */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerCreateSharedGroup(FString SharedGroupId);
+
+	/** Delete Shared Group */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerDeleteSharedGroup(FString SharedGroupId);
+
+	/** Get Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerGetPublisherData(TArray<FString> Keys);
+
+	/** Get Shared Group Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerGetSharedGroupData(FString SharedGroupId, TArray<FString> Keys, bool GetMembers = true);
+
+	/** Remove Shared Group Memebers */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerRemoveSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds);
+
+	/** Set Publisher Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerSetPublisherData(FString Key, FString Value);
+
+	/** Update Shared Group Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Shared Group Data")
+		static UVaRestPlayFabManager* ConstructServerUpdateSharedGroupData(FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+	
+	// Content
+
+	/** Get Content Download Url */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Content")
+		static UVaRestPlayFabManager* ConstructServerGetContentDownloadUrl(FString Key, FString HttpMethod = "", bool ThruCDN = true);
+
+	// Characters
+
+	/** Delete Character From User */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerDeleteCharacterFromUser(FString PlayFabId, FString CharacterId, bool SaveCharacterInventory = false);
+
+	/** Get All Users Characters */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGetAllUsersCharacters(FString PlayFabId);
+
+	/** Get Character Leaderboard */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterLeaderboard(FString CharacterId, FString StatisticName, int32 MaxResultsCount,
+		FString CharacterType = "", int32 StartPosition = 0);
+
+	/** Get Character Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterStatistics(FString PlayFabId, FString CharacterId);
+
+	/** Get Leaderboard Around Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGetLeaderboardAroundCharacter(FString PlayFabId, FString CharacterId, FString StatisticName, int32 MaxResultsCount,
+		FString CharacterType = "");
+
+	/** Get Leaderboard For User Character */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGetLeaderboardForUserCharacters(FString PlayFabId, FString StatisticName, int32 MaxResultsCount);
+
+	/** Grant Character To User */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerGrantCharacterToUser(FString PlayFabId, FString CharacterType, FString CharacterName);
+
+	/** Update Character Statistics */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Characters")
+		static UVaRestPlayFabManager* ConstructServerUpdateCharacterStatistics(FString PlayFabId, FString CharacterId, UVaRestJsonObject* CharacterStatistics);
+
+	// Character Data
+
+	/** Get Character Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
+
+	/** Get Character Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterInternalData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
+
+	/** Get Character ReadOnly Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerGetCharacterReadOnlyData(FString PlayFabId, FString CharacterId, TArray<FString> Keys, int32 IfChangedFromDataVersion = 0);
+
+	/** Update Character Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerUpdateCharacterData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+
+	/** Update Character Internal Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerUpdateCharacterInternalData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+
+	/** Update Character ReadOnly Data */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Server | Character Data")
+		static UVaRestPlayFabManager* ConstructServerUpdateCharacterReadOnlyData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission);
+
+	// Admin
+
+	/** Create Json object that contains current version request request object */
+	UFUNCTION(BlueprintPure, Category = "PlayFab | Admin | CloudScript")
+	static UVaRestPlayFabManager* ConstructGetCloudScriptRevision(FString Version, FString Revision);
+
+	/** PlayFab Request Info */
+	FString PlayFabClass;
+	FString PlayFabSessionToken;
+	FString CloudScriptVersion;
+	bool isAdmin = false;
+	bool isServer = false;
+	bool isClient = false;
+	bool useSecretKey = false;
+	bool useSessionTicket = false;
+	bool cloudScript = false;
+
+	//////////////////////////////////////////////////////////////////////////
+	// Internal data
+private:
+	/** PlayFab App Id */
+	static FString PlayFabAppId;
+
+	/** PlayFab Api Key */
+	static FString PlayFabApiKey;
+	static FString PhotonRealtimeAppId;
+	static FString PhotonTurnbasedAppId;
+	static FString PhotonChatAppId;
+
+	/** PlayFab URL */
+	static FString PlayFabURL;
+	static FString PlayFabLogicURL;
+
+	
+};

--- a/Source/VaRestPlugin/Private/PlayFab/VaRestPlayFabManager.cpp
+++ b/Source/VaRestPlugin/Private/PlayFab/VaRestPlayFabManager.cpp
@@ -1,9 +1,10 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
+// Update to work with PlayFab 2015 Joshua Lyons
 
 #include "VaRestPluginPrivatePCH.h"
 
-FString UVaRestPlayFabManager::PlayFabURL(TEXT("https://<AppID>.playfabapi.com/"));
-FString UVaRestPlayFabManager::PlayFabLogicURL(TEXT("https://<AppID>.playfablogic.com/"));
+FString UVaRestPlayFabManager::PlayFabURL(TEXT("https://<AppId>.playfabapi.com/"));
+FString UVaRestPlayFabManager::PlayFabLogicURL(TEXT("https://<AppId>.playfablogic.com/"));
 FString UVaRestPlayFabManager::PlayFabAppId(TEXT(""));
 FString UVaRestPlayFabManager::PlayFabApiKey(TEXT(""));
 FString UVaRestPlayFabManager::PhotonRealtimeAppId(TEXT(""));
@@ -521,6 +522,99 @@ UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPlayFabIDsFromFacebook
 
 	// Setup request object
 	OutRestJsonObj->SetStringArrayField(TEXT("FacebookIDs"), FacebookIDs);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Retrieves the unique PlayFab identifiers for the given set of Game Center identifiers (referenced in the Game Center Programming Guide as the Player Identifier) */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPlayFabIDsFromGameCenterIDs(FString SessionTicket, TArray<FString> GameCenterIDs)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPlayFabIDsFromGameCenterIDs";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("GameCenterIDs"), GameCenterIDs);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Retrieves the unique PlayFab identifiers for the given set of PlayStation Network identifiers */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPlayFabIDsFromPSNAccountIDs(FString SessionTicket, TArray<FString> PSNAccountIDs)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPlayFabIDsFromPSNAccountIDs";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("PSNAccountIDs"), PSNAccountIDs);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Retrieves the unique PlayFab identifiers for the given set of Steam identifiers. The Steam identifiers are the profile IDs for the user accounts, available as SteamId in the Steamworks Community API calls */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPlayFabIDsFromSteamIDs(FString SessionTicket, TArray<FString> SteamIDs)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPlayFabIDsFromSteamIDs";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("SteamIDs"), SteamIDs);
 
 	// Add Request to manager
 	manager->SetRequestObject(OutRestJsonObj);

--- a/Source/VaRestPlugin/Private/PlayFab/VaRestPlayFabManager.cpp
+++ b/Source/VaRestPlugin/Private/PlayFab/VaRestPlayFabManager.cpp
@@ -1,0 +1,5174 @@
+// Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
+
+#include "VaRestPluginPrivatePCH.h"
+
+FString UVaRestPlayFabManager::PlayFabURL(TEXT("https://<AppID>.playfabapi.com/"));
+FString UVaRestPlayFabManager::PlayFabLogicURL(TEXT("https://<AppID>.playfablogic.com/"));
+FString UVaRestPlayFabManager::PlayFabAppId(TEXT(""));
+FString UVaRestPlayFabManager::PlayFabApiKey(TEXT(""));
+FString UVaRestPlayFabManager::PhotonRealtimeAppId(TEXT(""));
+FString UVaRestPlayFabManager::PhotonTurnbasedAppId(TEXT(""));
+FString UVaRestPlayFabManager::PhotonChatAppId(TEXT(""));
+
+UVaRestPlayFabManager::UVaRestPlayFabManager(const class FObjectInitializer& PCIP)
+	: Super(PCIP)
+{
+
+}
+
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructPlayFabRequest(
+	UObject* WorldContextObject, 
+	ERequestVerb::Type Verb,
+	ERequestContentType::Type ContentType)
+{
+	return (UVaRestPlayFabManager*)ConstructRequestExt(WorldContextObject, Verb, ContentType);
+}
+
+void UVaRestPlayFabManager::ProcessPlayFabURL(
+	const FString& PlayFabClass,
+	const FString& PlayFabSessionToken,
+	bool isAdmin, bool isServer, bool isClient,
+	bool useSecretKey, bool useSessionTicket,
+	bool cloudScript, FString cloudScriptVersion)
+{
+	FString RequestUrl = PlayFabURL;
+
+	// Build the full request url
+	if (cloudScript)
+	{
+		RequestUrl = PlayFabLogicURL + cloudScriptVersion + TEXT("/prod/");
+	}
+
+	if (isAdmin)
+	{
+		RequestUrl += TEXT("Admin");
+	}
+	if (isClient)
+	{
+		RequestUrl += TEXT("Client");
+	}
+	if (isServer)
+	{
+		RequestUrl += TEXT("Server");
+	}
+
+
+
+	if (!PlayFabClass.IsEmpty())
+	{
+		RequestUrl += "/" + PlayFabClass;
+	}
+
+	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
+	HttpRequest->SetURL(RequestUrl);
+
+	//HttpRequest->SetHeader("X-PlayFab-Application-Id", PlayFabAppId);
+	//HttpRequest->SetHeader("X-PlayFab-REST-API-Key", PlayFabApiKey);
+
+	if (!PlayFabSessionToken.IsEmpty())
+	{
+		HttpRequest->SetHeader("X-Authentication", PlayFabSessionToken);
+	}
+	if (useSecretKey)
+	{
+		HttpRequest->SetHeader("X-SecretKey", PlayFabApiKey);
+	}
+
+	ProcessRequest(HttpRequest);
+}
+
+void UVaRestPlayFabManager::ProcessPlayFabRequest()
+{
+	ProcessPlayFabURL(PlayFabClass, PlayFabSessionToken, isAdmin, isServer, isClient, useSecretKey, useSessionTicket, cloudScript, CloudScriptVersion);
+}
+
+void UVaRestPlayFabManager::SetPlayFabAuthData(FString AppId, FString ApiKey)
+{
+	PlayFabAppId = AppId;
+	PlayFabApiKey = ApiKey;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Play Fab Construction Helpers
+//////////////////////////////////////////////////////////////////////////
+
+//// Client
+/** Create Login with Play Fab Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithPlayFab(FString Username, FString Password)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithPlayFab";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("Username"), Username);
+	OutRestJsonObj->SetStringField(TEXT("Password"), Password);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Register with play fab request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRegisterWithPlayFab(FString Username, FString Password, FString Email)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RegisterPlayFabUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("Username"), Username);
+	OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	OutRestJsonObj->SetStringField(TEXT("Password"), Password);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Get Photon Authentication Toeken Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPhotonAuthenticationToken(FString SessionTicket, bool PhotonRealtime, bool PhotonTurnbased, bool PhotonChat)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPhotonAuthenticationToken";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	FString tmpString;
+	if (PhotonRealtime)
+	{
+		tmpString = PhotonRealtimeAppId;
+	}
+	if (PhotonTurnbased)
+	{
+		tmpString = PhotonTurnbasedAppId;
+	}
+	if (PhotonChat)
+	{
+		tmpString = PhotonChatAppId;
+	}
+	OutRestJsonObj->SetStringField(TEXT("PhotonApplicationId"), tmpString);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create a Login with Android Device Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithAndroidDeviceID(FString AndroidDeviceId, FString OSVersion, FString AndroidDeviceType, bool CreateAccount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithAndroidDeviceID";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("AndroidDeviceId"), AndroidDeviceId);
+
+	if (OSVersion != "")
+	{
+		OutRestJsonObj->SetStringField(TEXT("OS"), OSVersion);
+	}
+	if (AndroidDeviceType != "")
+	{
+		OutRestJsonObj->SetStringField(TEXT("AndroidDevice"), AndroidDeviceType);
+	}
+	if (CreateAccount)
+	{
+		OutRestJsonObj->SetStringField(TEXT("CreateAccount"), "True");
+	}
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Login with Play Fab  Email Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithEmail(FString Email, FString Password)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithEmailAddress";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	OutRestJsonObj->SetStringField(TEXT("Password"), Password);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Login with Facebook Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithFacebook(FString FacebookAccessToken, bool CreateAccount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithFacebook";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("AccessToken"), FacebookAccessToken);
+
+	if (CreateAccount) OutRestJsonObj->SetBoolField(TEXT("CreateAccount"), CreateAccount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Login with Google Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithGoogle(FString GoogleAccessToken, bool CreateAccount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithGoogleAccount";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("AccessToken"), GoogleAccessToken);
+
+	if (CreateAccount) OutRestJsonObj->SetBoolField(TEXT("CreateAccount"), CreateAccount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create a Login with IOSDevice Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithIOSDeviceID(FString IOSDeviceId, FString OSVersion, FString DeviceModel, bool CreateAccount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithIOSDeviceID";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("DeviceId"), IOSDeviceId);
+
+	if (OSVersion != "") OutRestJsonObj->SetStringField(TEXT("OS"), OSVersion);
+	if (DeviceModel != "") OutRestJsonObj->SetStringField(TEXT("DeviceModel"), DeviceModel);
+	if (CreateAccount) OutRestJsonObj->SetBoolField(TEXT("CreateAccount"), CreateAccount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Login with Steam Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLoginWithSteam(FString SteamAccessToken, bool CreateAccount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LoginWithSteam";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+	OutRestJsonObj->SetStringField(TEXT("SteamTicket"), SteamAccessToken);
+	if (CreateAccount) OutRestJsonObj->SetBoolField(TEXT("CreateAccount"), CreateAccount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add Username Password Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAddUsernamePassword(FString SessionTicket, FString Email, FString Username, FString Password)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddUsernamePassword";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Username"), Username);
+	OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	OutRestJsonObj->SetStringField(TEXT("Password"), Password);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Account Info Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetAccountInfo(FString SessionTicket, FString PlayFabId, FString Username, FString Email, FString TitleDisplayName)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetAccountInfo";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+
+	if (Username != "")
+	{
+		OutRestJsonObj->SetStringField(TEXT("Username"), Username);
+	}
+	if (Email != "")
+	{
+		OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	}
+	if (TitleDisplayName != "")
+	{
+		OutRestJsonObj->SetStringField(TEXT("TitleDisplayName"), TitleDisplayName);
+	}
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get PlayFabIds from Facebook Ids */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPlayFabIDsFromFacebookIDs(FString SessionTicket, TArray<FString> FacebookIDs)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPlayFabIDsFromFacebookIDs";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("FacebookIDs"), FacebookIDs);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User combined info all inputs are optional except the session ticket.*/
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserCombinedInfo(FString SessionTicket, TArray<FString> UserDataKeys,
+	TArray<FString> ReadOnlyDataKey, FString PlayFabId, FString Username,
+	FString Email, FString TitleDisplayName, bool GetAccountInfo, bool GetInventory, bool GetVirtualCurrency,
+	bool GetUserData, bool GetReadOnlyData)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserCombinedInfo";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (PlayFabId != "") OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	if (Username!= "") OutRestJsonObj->SetStringField(TEXT("Username"), Username);
+	if (Email != "") OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	if (TitleDisplayName != "") OutRestJsonObj->SetStringField(TEXT("TitleDisplayName"), TitleDisplayName);
+	if (GetAccountInfo) OutRestJsonObj->SetBoolField(TEXT("GetAccountInfo"), GetAccountInfo);
+	if (GetInventory) OutRestJsonObj->SetBoolField(TEXT("GetInventory"), GetInventory);
+	if (GetVirtualCurrency) OutRestJsonObj->SetBoolField(TEXT("GetVirtualCurrency"), GetVirtualCurrency);
+	if (GetUserData) OutRestJsonObj->SetBoolField(TEXT("GetUserData"), GetUserData);
+	if (UserDataKeys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("UserDataKeys"), UserDataKeys);
+	if (GetReadOnlyData) OutRestJsonObj->SetBoolField(TEXT("GetReadOnlyData"), GetReadOnlyData);
+	if (ReadOnlyDataKey.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("ReadOnlyDataKeys"), ReadOnlyDataKey);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link android device ID */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId, FString OSVersion, FString AndroidDeviceType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkAndroidDeviceID";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("AndroidDeviceId"), AndroidDeviceId);
+
+	if (OSVersion != "") OutRestJsonObj->SetStringField(TEXT("OS"), OSVersion);
+	if (AndroidDeviceType != "") OutRestJsonObj->SetStringField(TEXT("AndroidDevice"), AndroidDeviceType);
+	
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link FacebookAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkFacebookAccount(FString SessionTicket, FString FacebookAccessToken)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkFacebookAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("AccessToken"), FacebookAccessToken);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link GameCenterAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkGameCenterAccount(FString SessionTicket, FString GameCenterId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkGameCenterAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("GameCenterId"), GameCenterId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link GoogleAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkGoogleAccount(FString SessionTicket, FString GoogleAccessToken)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkGoogleAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("AccessToken"), GoogleAccessToken);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link IOS device ID */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId, FString OSVersion, FString IOSDeviceModel)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkIOSDeviceID";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("DeviceId"), IOSDeviceId);
+
+	if (OSVersion != "") OutRestJsonObj->SetStringField(TEXT("OS"), OSVersion);
+	if (IOSDeviceModel != "") OutRestJsonObj->SetStringField(TEXT("DeviceModel"), IOSDeviceModel);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Link SteamAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLinkSteamAccount(FString SessionTicket, FString SteamAccessToken)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LinkSteamAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SteamTicket"), SteamAccessToken);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create SendAccountRecoverEmail */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructSendAccountRecoverEmail(FString Email)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SendAccountRecoverEmail";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Email"), Email);
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink android device ID */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkAndroidDeviceID(FString SessionTicket, FString AndroidDeviceId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkAndroidDeviceID";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("AndroidDeviceId"), AndroidDeviceId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink FacebookAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkFacebookAccount(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkFacebookAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink GameCenterAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkGameCenterAccount(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkGameCenterAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink GoogleAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkGoogleAccount(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkGoogleAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink IOS device ID */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkIOSDeviceID(FString SessionTicket, FString IOSDeviceId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkIOSDeviceID";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("DeviceId"), IOSDeviceId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UnLink SteamAccount */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlinkSteamAccount(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlinkSteamAccount";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create UpdateUserTitleDisplayName */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateUserTitleDisplayName(FString SessionTicket, FString DisplayName)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserTitleDisplayName";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("DisplayName"), DisplayName);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create GetFriendLeaderboard */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetFriendLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetFriendLeaderboard";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	if (StartPosition > 0) OutRestJsonObj->SetNumberField(TEXT("StatisticName"), StartPosition);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create GetLeaderboard */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount, int32 StartPosition)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboard";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	if (StartPosition > 0) OutRestJsonObj->SetNumberField(TEXT("StatisticName"), StartPosition);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create GetLeaderboardAroundCurrentUser */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetLeaderboardAroundCurrentUser(FString SessionTicket, FString StatisticName, int32 MaxResultsCount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardAroundCurrentUser";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Data*/
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("StatisticName"), Keys);
+	if (PlayFabId != "") OutRestJsonObj->SetStringField(TEXT("MaxResultsCount"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Publisher Data*/
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserPublisherData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserPublisherData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("StatisticName"), Keys);
+	if (PlayFabId != "") OutRestJsonObj->SetStringField(TEXT("MaxResultsCount"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Publisher Read Only Data*/
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserPublisherReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserPublisherReadOnlyData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("StatisticName"), Keys);
+	if (PlayFabId != "") OutRestJsonObj->SetStringField(TEXT("MaxResultsCount"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Read Only Data*/
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserReadOnlyData(FString SessionTicket, TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserReadOnlyData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("StatisticName"), Keys);
+	if (PlayFabId != "") OutRestJsonObj->SetStringField(TEXT("MaxResultsCount"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserStatistics(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateUserData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	if (PermissionType == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateUserPublisherData(FString SessionTicket, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserPublisherData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	if (PermissionType == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateUserStatistics(FString SessionTicket, UVaRestJsonObject* Statistics)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserStatistics";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetObjectField(TEXT("UserStatistics"), Statistics);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Catalog Items */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCatalogItems(FString SessionTicket, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCatalogItems";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Store Items */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetStoreItems(FString SessionTicket, FString StoreId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetStoreItems";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StoreId"), StoreId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Title Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetTitleData(FString SessionTicket, TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetTitleData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Title News */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetTitleNews(FString SessionTicket, int32 NumberofEntries)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetTitleNews";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetNumberField(TEXT("Count"), NumberofEntries);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add User Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAddUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddUserVirtualCurrency";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Consume Item */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructConsumeItem(FString SessionTicket, FString ItemInstanceId, int32 ConsumeCount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ConsumeItem";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+	OutRestJsonObj->SetNumberField(TEXT("ConsumeCount"), ConsumeCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Inventory */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCharacterInventory(FString SessionTicket, FString PlayFabId, FString CharacterId, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterInventory";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Inventory */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserInventory(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserInventory";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Redeem Coupon */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRedeemCoupon(FString SessionTicket, FString CouponCode, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RedeemCoupon";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CouponCode"), CouponCode);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Report Player */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructReportPlayer(FString SessionTicket, FString ReportedId, FString Reason)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ReportPlayer";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ReporteeId"), ReportedId);
+	OutRestJsonObj->SetStringField(TEXT("Comment"), Reason);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Subtract User Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructSubtractUserVirtualCurrency(FString SessionTicket, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SubtractUserVirtualCurrency";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Unlock Container Item */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUnlockContainerItem(FString SessionTicket, FString ContainerItemId, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UnlockContainerItem";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ContainerItemId"), ContainerItemId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Start Purchase */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructStartPurchase(FString SessionTicket, UVaRestJsonObject* Items, FString CatalogVersion, FString StoreId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "StartPurchase";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+	if (StoreId != "") OutRestJsonObj->SetStringField(TEXT("StoreId"), StoreId);
+	OutRestJsonObj->SetObjectField(TEXT("Items"), Items);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Pay For Purchase */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructPayForPurchase(FString SessionTicket, FString OrderId, FString ProviderName, FString Currency)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "PayForPurchase";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("OrderId"), OrderId);
+	OutRestJsonObj->SetStringField(TEXT("ProviderName"), ProviderName);
+	OutRestJsonObj->SetStringField(TEXT("Currency"), Currency);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Confirm Purchase */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructConfirmPurchase(FString SessionTicket, FString OrderId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ConfirmPurchase";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("OrderId"), OrderId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** PurchaseItem */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructPurchaseItem(FString SessionTicket, FString ItemId, FString VirtualCurrency,
+	int32 Price, FString CatalogVersion, FString StoreId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "PurchaseItem";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ItemId"), ItemId);
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Price"), Price);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+	if (StoreId != "") OutRestJsonObj->SetStringField(TEXT("StoreId"), StoreId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add Friend */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAddFriend(FString SessionTicket, FString FriendPlayFabId, FString FriendUsername,
+	FString FriendEmail, FString FriendTitleDisplayName)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddFriend";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (FriendPlayFabId != "") OutRestJsonObj->SetStringField(TEXT("FrienPlayFabId"), FriendPlayFabId);
+	if (FriendUsername != "") OutRestJsonObj->SetStringField(TEXT("FriendUsername"), FriendUsername);
+	if (FriendEmail != "") OutRestJsonObj->SetStringField(TEXT("FriendEmail"), FriendEmail);
+	if (FriendTitleDisplayName != "") OutRestJsonObj->SetStringField(TEXT("FriendTitleDisplayName"), FriendTitleDisplayName);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Friends List */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetFriendsList(FString SessionTicket, bool IncludeSteamFriends, bool IncludeFacebookFriends)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetFriendsList";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (IncludeSteamFriends) OutRestJsonObj->SetBoolField(TEXT("IncludeSteamFriends"), IncludeSteamFriends);
+	if (IncludeFacebookFriends) OutRestJsonObj->SetBoolField(TEXT("IncludeFacebookFriends"), IncludeFacebookFriends);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Remove Friend */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRemoveFriend(FString SessionTicket, FString FriendPlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RemoveFriend";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("FriendPlayFabId"), FriendPlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Set Friend Tags */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructSetFriendTags(FString SessionTicket, FString FriendPlayFabId, TArray<FString> Tags)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SetFriendTags";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("FriendPlayFabId"), FriendPlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Tags"), Tags);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Register For IOS Push Notifications */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRegisterFORIOSPushNotifications(FString SessionTicket, FString DeviceToken, bool SendPushNotificationConfirmation, FString ConfirmationMessage)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RegisterForIOSPushNotifications";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("DeviceToken"), DeviceToken);
+	if (SendPushNotificationConfirmation) OutRestJsonObj->SetBoolField(TEXT("SendPushNotificationConfirmation"), SendPushNotificationConfirmation);
+	if (SendPushNotificationConfirmation) OutRestJsonObj->SetStringField(TEXT("ConfirmationMessage"), ConfirmationMessage);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Restore IOS Purchases */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRestoreIOSPurchases(FString SessionTicket, FString Base64ReceiptData)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RestoreIOSPurchases";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ReceiptData"), Base64ReceiptData);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Validate IOS Reciept */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructValidateIOSReceipt(FString SessionTicket, FString Base64ReceiptData, FString CurrencyCode, FString PurchasePrice)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ValidateIOSReceipt";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ReceiptData"), Base64ReceiptData);
+	OutRestJsonObj->SetStringField(TEXT("CurrencyCode"), CurrencyCode);
+	OutRestJsonObj->SetStringField(TEXT("PurchasePrice"), PurchasePrice);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Current Games */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCurrentGames(FString SessionTicket, ERegion::Type Region, FString BuildVersion, FString GameMode, FString StatisticName)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCurrentGames";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Region != ERegion::Type::ANY)
+	{
+		if (Region == ERegion::Type::AUSTRALIA) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Australia"));
+		if (Region == ERegion::Type::BRAZIL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Brazil"));
+		if (Region == ERegion::Type::EUWEST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("EUWest"));
+		if (Region == ERegion::Type::JAPAN) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Japan"));
+		if (Region == ERegion::Type::SINGAPORE) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Singapore"));
+		if (Region == ERegion::Type::USCENTRAL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USCentral"));
+		if (Region == ERegion::Type::USEAST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USEast"));
+	}
+	if (BuildVersion != "") OutRestJsonObj->SetStringField(TEXT("BuildVersion"), BuildVersion);
+	if (GameMode != "") OutRestJsonObj->SetStringField(TEXT("GameMode"), GameMode);
+	if (StatisticName != "") OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Game Server Regions */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetGameServerRegions(FString SessionTicket, FString BuildVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetGameServerRegions";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("BuildVersion"), BuildVersion);
+	OutRestJsonObj->SetStringField(TEXT("TitleId"), PlayFabAppId);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Matchmake */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructMatchmake(FString SessionTicket, ERegion::Type Region, FString BuildVersion, FString GameMode,
+	FString LobbyId, FString StatisticName, FString CharacterId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "Matchmake";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (BuildVersion != "") OutRestJsonObj->SetStringField(TEXT("BuildVersion"), BuildVersion);
+	if (Region != ERegion::Type::ANY)
+	{
+		if (Region == ERegion::Type::AUSTRALIA) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Australia"));
+		if (Region == ERegion::Type::BRAZIL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Brazil"));
+		if (Region == ERegion::Type::EUWEST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("EUWest"));
+		if (Region == ERegion::Type::JAPAN) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Japan"));
+		if (Region == ERegion::Type::SINGAPORE) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Singapore"));
+		if (Region == ERegion::Type::USCENTRAL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USCentral"));
+		if (Region == ERegion::Type::USEAST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USEast"));
+	}
+	if (GameMode != "") OutRestJsonObj->SetStringField(TEXT("GameMode"), GameMode);
+	if (LobbyId != "") OutRestJsonObj->SetStringField(TEXT("LobbyId"), BuildVersion);
+	if (StatisticName!= "") OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	if (CharacterId != "") OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+
+}
+
+/** Start Game */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructStartGame(FString SessionTicket, FString BuildVersion, ERegion::Type Region, FString GameMode, FString StatisticName,
+	FString CharacterId, bool PasswordRestricted, FString CustomCommandLineData)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "Matchmake";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("BuildVersion"), BuildVersion);
+	if (Region != ERegion::Type::ANY)
+	{
+		if (Region == ERegion::Type::AUSTRALIA) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Australia"));
+		if (Region == ERegion::Type::BRAZIL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Brazil"));
+		if (Region == ERegion::Type::EUWEST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("EUWest"));
+		if (Region == ERegion::Type::JAPAN) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Japan"));
+		if (Region == ERegion::Type::SINGAPORE) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("Singapore"));
+		if (Region == ERegion::Type::USCENTRAL) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USCentral"));
+		if (Region == ERegion::Type::USEAST) OutRestJsonObj->SetStringField(TEXT("Region"), TEXT("USEast"));
+	}
+	OutRestJsonObj->SetStringField(TEXT("GameMode"), GameMode);
+	if (StatisticName != "") OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	if (CharacterId != "") OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (PasswordRestricted) OutRestJsonObj->SetBoolField(TEXT("PasswordRestrcted"), PasswordRestricted);
+	if (CustomCommandLineData != "") OutRestJsonObj->SetStringField(TEXT("CustomCommandLineData"), CustomCommandLineData);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Android Device Push Notification Registration */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAndroidDevicePushNotificationRegistration(FString SessionTicket, 
+	FString DeviceToken, bool SendPushNotificationConfirmation,	FString ConfirmationMessage)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AndroidDevicePushNotificationRegistration";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("DeviceToken"), DeviceToken);
+	if (SendPushNotificationConfirmation) OutRestJsonObj->SetBoolField(TEXT("SendPushNotificationConfirmation"), SendPushNotificationConfirmation);
+	if (SendPushNotificationConfirmation) OutRestJsonObj->SetStringField(TEXT("ConfirmationMessage"), ConfirmationMessage);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Validate Google Play Purchase */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructValidateGooglePlayPurchase(FString SessionTicket, FString ReceiptJsonString, FString Signature)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ValidateGooglePlayPurchase";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ReceiptJson"), ReceiptJsonString);
+	OutRestJsonObj->SetStringField(TEXT("Signature"), Signature);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Log Event */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructLogEvent(FString SessionTicket, FString EventName, UVaRestJsonObject* Body, bool ProfileSetEvent)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LogEvent";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("EventName"), EventName);
+	OutRestJsonObj->SetObjectField(TEXT("Body"), Body);
+	if (ProfileSetEvent) OutRestJsonObj->SetBoolField(TEXT("ProfileSetEvent"), ProfileSetEvent);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add Shared Group Memebers */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAddSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddSharedGroupMembers";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Shared Group */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructCreateSharedGroup(FString SessionTicket, FString SharedGroupId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "CreateSharedGroup";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetPublisherData(FString SessionTicket, TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPublisherData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Shared Group Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetSharedGroupData(FString SessionTicket, FString SharedGroupId, TArray<FString> Keys, bool GetMembers)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetSharedGroupData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+	OutRestJsonObj->SetBoolField(TEXT("ProfileSetEvent"), GetMembers);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Remove Shared Group Memebers */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRemoveSharedGroupMembers(FString SessionTicket, FString SharedGroupId, TArray<FString> PlayFabIds)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RemoveSharedGroupMembers";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Shared Group Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateSharedGroupData(FString SessionTicket, FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateSharedGroupData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	if (Permission == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** RefreshPSNAuthToken */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRefreshPSNAuthToken(FString SessionTicket, FString PSNAuthCode)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RefreshPSNAuthToken";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("AuthToken"), PSNAuthCode);
+	
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Cloud Script Url */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCloudScriptUrl(FString SessionTicket, int32 Version, bool Testing)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCloudScriptUrl";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (Version > 0) OutRestJsonObj->SetNumberField(TEXT("Version"), Version);
+	if (Testing) OutRestJsonObj->SetBoolField(TEXT("Testing"), Testing);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Run Cloud Script */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructRunCloudScript(FString SessionTicket, FString ActionId, UVaRestJsonObject* Params, FString ParamsEncoded)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RunCloudScript";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = true;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ActionId"), ActionId);
+	OutRestJsonObj->SetObjectField(TEXT("Params"), Params);
+	if (ParamsEncoded != "") OutRestJsonObj->SetStringField(TEXT("ParamsEncoded"), ParamsEncoded);
+	
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Content Download Url */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetContentDownloadUrl(FString SessionTicket, FString Key, FString HttpMethod, bool ThruCDN)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetContentDownloadUrl";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Key"), Key);
+	if (HttpMethod != "") OutRestJsonObj->SetStringField(TEXT("HttpMethod"), HttpMethod);
+	OutRestJsonObj->SetBoolField(TEXT("ThruCDN"), ThruCDN);
+	
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Leaderboard */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCharacterLeaderboard(FString SessionTicket, FString StatisticName, int32 MaxResultsCount,
+	FString CharacterType, int32 StartPosition)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterLeaderboard";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+	if (CharacterType != "") OutRestJsonObj->SetStringField(TEXT("CharacterType"), CharacterType);
+	if (StartPosition > 0) OutRestJsonObj->SetNumberField(TEXT("StartPosition"), StartPosition);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Leaderboard Around Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetLeaderboardAroundCharacter(FString SessionTicket, FString CharacterId, FString StatisticName, 
+	int32 MaxResultsCount, FString CharacterType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardAroundCharacter";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+	if (CharacterType != "") OutRestJsonObj->SetStringField(TEXT("CharacterType"), CharacterType);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Leaderboard For User Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetLeaderboardForUserCharacters(FString SessionTicket, FString StatisticName, int32 MaxResultsCount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardForUserCharacters";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Grant Character To User */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGrantCharacterToUser(FString SessionTicket, FString ItemId, FString CharacterName, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GrantCharacterToUser";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ItemId"), ItemId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterName"), CharacterName);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCharacterData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character ReadOnly Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCharacterReadOnlyData(FString SessionTicket, FString PlayFabId, FString CharacterId, TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterReadOnlyData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (Keys.Num() > 0) OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Character Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructUpdateCharacterData(FString SessionTicket, FString CharacterId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateCharacterData";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = false;
+	manager->isClient = true;
+	manager->useSecretKey = false;
+	manager->useSessionTicket = true;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	if (Permission == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+//// Server
+/** Create AuthenticateSessionTicket Request */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructAuthenticateSessionTicket(FString SessionTicket)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AuthenticateSessionTicket";
+	manager->PlayFabSessionToken = SessionTicket;
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SessionTicket"), SessionTicket);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Account Info */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetUserAccountInfo(FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserAccountInfo";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Send Push Notification */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructSendPushNotification(FString RecipientPlayFabId, FString Message, FString Subject)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SendPushNotification";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Recipient"), RecipientPlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("Message"), Message);
+	if (Subject != "") OutRestJsonObj->SetStringField(TEXT("Subject"), Subject);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create GetLeaderboard */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetLeaderboard(FString StatisticName, int32 MaxResultsCount, int32 StartPosition)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboard";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	if (StartPosition > 0) OutRestJsonObj->SetNumberField(TEXT("StatisticName"), StartPosition);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create GetLeaderboardAroundUser */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetLeaderboardAroundUser(FString StatisticName, FString PlayFabId, int32 MaxResultsCount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardAroundUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), PlayFabId);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserInternalData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserInternal";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserPublisherData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserPublisherData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserPublisherInternalData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserPublisherInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Publisher Read Only Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserPublisherReadOnlyData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserPublisherReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Read Only Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserReadOnlyData(TArray<FString> Keys, FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserStatistics(FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserStatistics";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserInternalData(FString PlayFabId, UVaRestJsonObject* Data)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	//if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	//if (Permissiontype == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserPublisherData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserPublisherData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Publisher Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserPublisherInternalData(FString PlayFabId, UVaRestJsonObject* Data)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserPublisherInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	//if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	//if (Permissiontype == EUserDataPermision::Type::PRIVATE) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Publisher ReadOnly Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserPublisherReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserPublisherReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User ReadOnly Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserReadOnlyData(FString PlayFabId, UVaRestJsonObject* Data, EUserDataPermision::Type PermissionType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (PermissionType == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserStatistics(FString PlayFabId, UVaRestJsonObject* Statistics)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserStatistics";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetObjectField(TEXT("UserStatistics"), Statistics);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Catalog Items */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCatalogItems(FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCatalogItems";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Title Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetTitleData(TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetTitleData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Title Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetTitleInternalData(TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetTitleInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Set Title Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerSetTitleData(FString Key, FString Value)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SetTitleData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Key"), Key);
+	OutRestJsonObj->SetStringField(TEXT("Value"), Value);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Title nternal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerSetTitleInternalData(FString Key, FString Value)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SetTitleInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Key"), Key);
+	OutRestJsonObj->SetStringField(TEXT("Value"), Value);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add Character Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerAddCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddCharacterVirtualCurrency";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add User Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerAddUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddUserVirtualCurrency";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	//OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Inventory */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterInventory(FString PlayFabId, FString CharacterId, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterInventory";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get User Inventory */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetUserInventory(FString PlayFabId, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetUserInventory";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	//OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Grant Items To Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGrantItemsToCharacter(FString PlayFabId, FString CharacterId, TArray<FString> ItemIds, FString CatalogVersion,
+	FString Annotation)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GrantItemsToCharacter";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+	if (Annotation!= "") OutRestJsonObj->SetStringField(TEXT("Annotation"), Annotation);
+	OutRestJsonObj->SetStringArrayField(TEXT("ItemIds"), ItemIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Grant Items To User */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGrantItemsToUser(FString PlayFabId, TArray<FString> ItemIds, FString CatalogVersion,
+	FString Annotation)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GrantItemsToUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	//OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+	if (Annotation != "") OutRestJsonObj->SetStringField(TEXT("Annotation"), Annotation);
+	OutRestJsonObj->SetStringArrayField(TEXT("ItemIds"), ItemIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Grant Items To Users */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGrantItemsToUsers(UVaRestJsonObject* ItemGrants, FString CatalogVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GrantItemsToUsers";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	if (CatalogVersion != "") OutRestJsonObj->SetStringField(TEXT("CatalogVersion"), CatalogVersion);
+	OutRestJsonObj->SetObjectField(TEXT("ItemGrants"), ItemGrants);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Modify Item Uses */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerModifyItemUses(FString PlayFabId, FString ItemInstanceId, int32 UsesToAdd)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ModifyItemUses";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+	OutRestJsonObj->SetNumberField(TEXT("UsesToAdd"), UsesToAdd);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Move Item To Character From Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerMoveItemToCharacterFromCharacter(FString PlayFabId, FString GivingCharacterId,
+	FString ReceivingCharacterId, FString ItemInstanceId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "MoveItemToCharacterFromCharacter";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("GivingCharacterId"), GivingCharacterId);
+	OutRestJsonObj->SetStringField(TEXT("ReceivingCharacterId"), ReceivingCharacterId);
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+	
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Move Item To Character From User */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerMoveItemToCharacterFromUser(FString PlayFabId, FString CharacterId,
+	FString ItemInstanceId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "MoveItemToCharacterFromUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Move Item To User From Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerMoveItemToUserFromCharacter(FString PlayFabId, FString CharacterId,
+	FString ItemInstanceId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "MoveItemToUserFromCharacter";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Report Player */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerReportPlayer(FString ReporterPlayFabId, FString ReporteePlayFabId,
+	FString TitleId, FString Comment)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "ReportPlayer";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("ReporterPlayFabId"), ReporterPlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("ReporteePlayFabId"), ReporteePlayFabId);
+	if (TitleId != "") OutRestJsonObj->SetStringField(TEXT("TitleId"), TitleId);
+	if (Comment != "") OutRestJsonObj->SetStringField(TEXT("Comment"), Comment);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Subtract Character Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerSubtractCharacterVirtualCurrency(FString PlayFabId, FString CharacterId, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SubtractCharacterVirtualCurrency";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Subtract User Virtual Currency */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerSubtractUserVirtualCurrency(FString PlayFabId, FString VirtualCurrency, int32 Amount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SubtractUserVirtualCurrency";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	//OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("VirtualCurrency"), VirtualCurrency);
+	OutRestJsonObj->SetNumberField(TEXT("Amount"), Amount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update User Inventory Item Custom Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateUserInventoryItemCustomData(FString PlayFabId, FString ItemInstanceId,
+	UVaRestJsonObject* Data, FString CharacterId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateUserInventoryCustomData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("ItemInstanceId"), ItemInstanceId);
+	if (CharacterId != "") OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Notify Matchmaker Player Left */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerNotifyMatchmakerPlayerLeft(FString PlayFabId, FString LobbyId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "NotifyMatchmakerPlayerLeft";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("LobbyId"), LobbyId);
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Redeem Matchmaker Ticket */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerRedeemMatchmakerTicket(FString Ticket, FString LobbyId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RedeemMatchmakerTicket";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Ticket"), Ticket);
+	OutRestJsonObj->SetStringField(TEXT("LobbyId"), LobbyId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Award Steam Achievement */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerAwardSteamAchievement(UVaRestJsonObject* Achievements)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AwardSteamAchievement";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetObjectField(TEXT("Achievements"), Achievements);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Log Event */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerLogEvent(FString EventName, UVaRestJsonObject* Body, FString PlayFabId,
+	FString EntityId, FString EntityType, bool PlayerEvent, bool ProfileSetEvent)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "LogEvent";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("EventName"), EventName);
+	OutRestJsonObj->SetObjectField(TEXT("Body"), Body);
+
+	if (PlayerEvent) OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	else
+	{
+		OutRestJsonObj->SetStringField(TEXT("EntityId"), EntityId);
+		OutRestJsonObj->SetStringField(TEXT("EntityType"), EntityType);
+	}
+
+	if (ProfileSetEvent) OutRestJsonObj->SetBoolField(TEXT("ProfileSetEvent"), ProfileSetEvent);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Add Shared Group Memebers */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerAddSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "AddSharedGroupMembers";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Create Shared Group */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerCreateSharedGroup(FString SharedGroupId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "CreateSharedGroup";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	//OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Delete Shared Group */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerDeleteSharedGroup(FString SharedGroupId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "DeleteSharedGroup";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	//OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetPublisherData(TArray<FString> Keys)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetPublisherData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	//OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Shared Group Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetSharedGroupData(FString SharedGroupId, TArray<FString> Keys, bool GetMembers)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetSharedGroupData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+	if (GetMembers) OutRestJsonObj->SetBoolField(TEXT("GetMembers"), GetMembers);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Remove Shared Group Memebers */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerRemoveSharedGroupMembers(FString SharedGroupId, TArray<FString> PlayFabIds)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "RemoveSharedGroupMembers";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetStringArrayField(TEXT("PlayFabIds"), PlayFabIds);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Set Publisher Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerSetPublisherData(FString Key, FString Value)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "SetPublisherData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Key"), Key);
+	OutRestJsonObj->SetStringField(TEXT("Value"), Value);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Shared Group Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateSharedGroupData(FString SharedGroupId, UVaRestJsonObject* Data, EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateSharedGroupData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("SharedGroupId"), SharedGroupId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+	
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Content Download Url */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetContentDownloadUrl(FString Key, FString HttpMethod, bool ThruCDN)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetContentDownloadUrl";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Key"), Key);
+	if (HttpMethod != "") OutRestJsonObj->SetStringField(TEXT("HttpMethod"), HttpMethod);
+	OutRestJsonObj->SetBoolField(TEXT("ThruCDN"), ThruCDN);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Delete Character From User */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerDeleteCharacterFromUser(FString PlayFabId, FString CharacterId, bool SaveCharacterInventory)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "DeleteCharacterFromUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	if (SaveCharacterInventory) OutRestJsonObj->SetBoolField(TEXT("SaveCharacterInventory"), SaveCharacterInventory);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get All Users Characters */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetAllUsersCharacters(FString PlayFabId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetAllUsersCharacters";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Leaderboard */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterLeaderboard(FString CharacterId, FString StatisticName, int32 MaxResultsCount,
+	FString CharacterType, int32 StartPosition)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterLeaderboard";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+	if (CharacterType != "") OutRestJsonObj->SetStringField(TEXT("CharacterType"), CharacterType);
+	if (StartPosition > 0) OutRestJsonObj->SetNumberField(TEXT("StartPosition"), StartPosition);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterStatistics(FString PlayFabId, FString CharacterId)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterStatistics";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Leaderboard Around Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetLeaderboardAroundCharacter(FString PlayFabId, FString CharacterId, FString StatisticName, int32 MaxResultsCount,
+	FString CharacterType)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardAroundCharacter";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+	if (CharacterType != "") OutRestJsonObj->SetStringField(TEXT("CharacterType"), CharacterType);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Leaderboard For User Character */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetLeaderboardForUserCharacters(FString PlayFabId, FString StatisticName, int32 MaxResultsCount)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetLeaderboardForUserCharacters";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("StatisticName"), StatisticName);
+	OutRestJsonObj->SetNumberField(TEXT("MaxResultsCount"), MaxResultsCount);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Grant Character To User */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGrantCharacterToUser(FString PlayFabId, FString CharacterType, FString CharacterName)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GrantCharacterToUser";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterName"), CharacterName);
+	OutRestJsonObj->SetStringField(TEXT("CharacterType"), CharacterType);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Character Statistics */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateCharacterStatistics(FString PlayFabId, FString CharacterId, UVaRestJsonObject* CharacterStatistics)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateCharacterStatistics";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("CharacterStatistics"), CharacterStatistics);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterData(FString PlayFabId, FString CharacterId, TArray<FString> Keys,
+	int32 IfChangedFromDataVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+	if (IfChangedFromDataVersion > 0) OutRestJsonObj->SetNumberField(TEXT("IfChangedFromDataVersion"), IfChangedFromDataVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterInternalData(FString PlayFabId, FString CharacterId, TArray<FString> Keys,
+	int32 IfChangedFromDataVersion)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+	if (IfChangedFromDataVersion > 0) OutRestJsonObj->SetNumberField(TEXT("IfChangedFromDataVersion"), IfChangedFromDataVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Get Character ReadOnly Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerGetCharacterReadOnlyData(FString PlayFabId, FString CharacterId, TArray<FString> Keys,
+	int32 IfChangedFromDataVersion )
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCharacterReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetStringArrayField(TEXT("Keys"), Keys);
+	if (IfChangedFromDataVersion > 0) OutRestJsonObj->SetNumberField(TEXT("IfChangedFromDataVersion"), IfChangedFromDataVersion);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Character Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateCharacterData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data,
+	EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateCharacterData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Character Internal Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateCharacterInternalData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data,
+	EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateCharacterInternalData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+/** Update Character ReadOnly Data */
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructServerUpdateCharacterReadOnlyData(FString PlayFabId, FString CharacterId, UVaRestJsonObject* Data,
+	EUserDataPermision::Type Permission)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "UpdateCharacterReadOnlyData";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = false;
+	manager->isServer = true;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("PlayFabId"), PlayFabId);
+	OutRestJsonObj->SetStringField(TEXT("CharacterId"), CharacterId);
+	OutRestJsonObj->SetObjectField(TEXT("Data"), Data);
+	if (Permission == EUserDataPermision::Type::PUBLIC) OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Public"));
+	else OutRestJsonObj->SetStringField(TEXT("Permission"), TEXT("Private"));
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}
+
+
+
+
+//// Admin
+UVaRestPlayFabManager* UVaRestPlayFabManager::ConstructGetCloudScriptRevision(FString Version, FString Revision)
+{
+	// Object containing request data
+	UVaRestPlayFabManager* manager = NewObject<UVaRestPlayFabManager>();
+	UVaRestJsonObject* OutRestJsonObj = NewObject<UVaRestJsonObject>();
+
+	// Setup request
+	manager->SetVerb(ERequestVerb::POST);
+	manager->SetContentType(ERequestContentType::json);
+
+	// Setup the request variables based on this request
+	manager->PlayFabClass = "GetCloudScriptRevision";
+	manager->PlayFabSessionToken = "";
+	manager->CloudScriptVersion = "";
+	manager->isAdmin = true;
+	manager->isServer = false;
+	manager->isClient = false;
+	manager->useSecretKey = true;
+	manager->useSessionTicket = false;
+	manager->cloudScript = false;
+
+	// Setup request object
+	OutRestJsonObj->SetStringField(TEXT("Version"), Version);
+	OutRestJsonObj->SetStringField(TEXT("Revision"), Revision);
+
+
+	// Add Request to manager
+	manager->SetRequestObject(OutRestJsonObj);
+
+	return manager;
+}


### PR DESCRIPTION
I created a PlayFab manager based off the Parse Manager. Completely blueprintable, just need to udate the PlayFabAppIds in the cpp file. It's at the top just like the ParseManager. To use Drag a PlayFabManager Object onto the graph. Then find the construction object you wish to use. Bind the OnComplete and OnFail events just like a normal. Next add a ProcessPlayFabUrl to the graph and the rest is taken care of in the code. Attached is an image of the Graph.

![bp1](https://cloud.githubusercontent.com/assets/7035829/8176369/e89b4fc2-13bf-11e5-874a-d35139f4c1e0.jpg)
