### PR TITLE
Added parameter to callbacks with payload of request

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestJsonObject.h
@@ -11,7 +11,7 @@ class UVaRestJsonValue;
  * Blueprintable FJsonObject wrapper
  */
 UCLASS(BlueprintType, Blueprintable)
-class UVaRestJsonObject : public UObject
+class VARESTPLUGIN_API UVaRestJsonObject : public UObject
 {
 	GENERATED_UCLASS_BODY()
 

--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -35,7 +35,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRequestComplete, class UVaRestReq
  * General helper class http requests via blueprints
  */
 UCLASS(BlueprintType, Blueprintable)
-class UVaRestRequestJSON : public UObject
+class VARESTPLUGIN_API UVaRestRequestJSON : public UObject
 {
 	GENERATED_UCLASS_BODY()
 

--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -30,6 +30,7 @@ namespace ERequestContentType
 
 /** Generate a delegates for callback events */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRequestComplete, class UVaRestRequestJSON*, Request);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRequestFail, class UVaRestRequestJSON*, Request);
 
 /**
  * General helper class http requests via blueprints
@@ -136,7 +137,7 @@ public:
 
 	/** Event occured when the request wasn't successfull */
 	UPROPERTY(BlueprintAssignable, Category = "VaRest")
-	FOnRequestComplete OnRequestFail;
+	FOnRequestFail OnRequestFail;
 
 
 	//////////////////////////////////////////////////////////////////////////

--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -29,8 +29,7 @@ namespace ERequestContentType
 }
 
 /** Generate a delegates for callback events */
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRequestComplete);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRequestFail);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRequestComplete, class UVaRestRequestJSON*, Request);
 
 /**
  * General helper class http requests via blueprints

--- a/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/Json/VaRestRequestJSON.cpp
@@ -257,7 +257,7 @@ void UVaRestRequestJSON::OnProcessRequestComplete(FHttpRequestPtr Request, FHttp
 		UE_LOG(LogVaRest, Error, TEXT("Request failed: %s"), *Request->GetURL());
 
 		// Broadcast the result event
-		OnRequestFail.Broadcast();
+		OnRequestFail.Broadcast(this);
 
 		return;
 	}
@@ -290,5 +290,5 @@ void UVaRestRequestJSON::OnProcessRequestComplete(FHttpRequestPtr Request, FHttp
 	}
 
 	// Broadcast the result event
-	OnRequestComplete.Broadcast();
+	OnRequestComplete.Broadcast(this);
 }


### PR DESCRIPTION
Callbacks now get request (UVaRestRequestJSON) as parameter.  C++ signature for callbacks:
void RestRequestComplete(UVaRestRequestJSON* Request);

This essentially makes it easier to track which request returned, in case we are firing off multiple requests while they are still being processed.

![image](https://cloud.githubusercontent.com/assets/3895512/8702595/cc397d9e-2b6c-11e5-8eb8-8adbe5766fe2.png)