### PR TITLE
Added binary request content option, async apply url via latent actions, and break_json blueprint node

### DIFF
--- a/Source/VaRestEditorPlugin/Private/VaRestEditorPlugin.cpp
+++ b/Source/VaRestEditorPlugin/Private/VaRestEditorPlugin.cpp
@@ -1,0 +1,27 @@
+// Some copyright should be here...
+
+#include "VaRestEditorPluginPrivatePCH.h"
+#include "VaRestEditorPlugin.h"
+
+
+
+#define LOCTEXT_NAMESPACE "FVaRestEditorPluginModule"
+
+void FVaRestEditorPluginModule::StartupModule()
+{
+	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+	
+	
+}
+
+void FVaRestEditorPluginModule::ShutdownModule()
+{
+	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+	// we call this function before unloading the module.
+	
+	
+}
+
+#undef LOCTEXT_NAMESPACE
+	
+IMPLEMENT_MODULE(FVaRestEditorPluginModule, VaRestEditorPlugin)

--- a/Source/VaRestEditorPlugin/Private/VaRestEditorPluginPrivatePCH.h
+++ b/Source/VaRestEditorPlugin/Private/VaRestEditorPluginPrivatePCH.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
+++ b/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
@@ -1,0 +1,269 @@
+#include "VaRestEditorPluginPrivatePCH.h"
+#include "KismetCompiler.h"
+#include "VaRest_BreakJson.h"
+#include "EditorCategoryUtils.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNodeUtils.h" // for FNodeTextCache
+#include "EdGraphSchema_K2.h"
+#include "BlueprintNodeSpawner.h"
+#include "BlueprintActionDatabaseRegistrar.h"
+#include "BlueprintFieldNodeSpawner.h"
+#include "EditorCategoryUtils.h"
+#include "BlueprintActionFilter.h"
+
+#define LOCTEXT_NAMESPACE "VaRest_BreakJson"
+
+class FKCHandler_BreakJson : public FNodeHandlingFunctor
+{
+	TArray<bool> bIsArray; // whether outputs are json arrays
+public:
+	FKCHandler_BreakJson(FKismetCompilerContext& InCompilerContext)
+		: FNodeHandlingFunctor(InCompilerContext)
+	{
+	}
+
+	virtual void Compile(FKismetFunctionContext& Context, UEdGraphNode* Node) override
+	{
+		UEdGraphPin* InputPin = NULL;
+		for (int32 PinIndex = 0; PinIndex < Node->Pins.Num(); ++PinIndex)
+		{
+			UEdGraphPin* Pin = Node->Pins[PinIndex];
+			if (Pin && (EGPD_Input == Pin->Direction))
+			{
+				InputPin = Pin;
+				break;
+			}
+		}
+		UEdGraphPin *InNet = FEdGraphUtilities::GetNetFromPin(InputPin);
+		UClass *Class = Cast<UClass>(StaticLoadObject(UClass::StaticClass(), NULL, TEXT("class'VaRestPlugin.VaRestJsonObject'")));
+		FBPTerminal **SourceTerm = Context.NetMap.Find(InNet);
+		if (SourceTerm == nullptr)
+		{
+			return;
+		}
+		for (int32 PinIndex = 0; PinIndex < Node->Pins.Num(); ++PinIndex)
+		{
+			UEdGraphPin* Pin = Node->Pins[PinIndex];
+			if (Pin && (EGPD_Output == Pin->Direction))
+			{
+				if (Pin->LinkedTo.Num() < 1)
+				{
+					continue;
+				}
+				FBPTerminal **Target = Context.NetMap.Find(Pin);
+				const FString &FieldName = Pin->PinName;
+				const FString &FieldType = Pin->PinType.PinCategory;
+				FBPTerminal* FieldNameTerm = Context.CreateLocalTerminal(ETerminalSpecification::TS_Literal);
+				FieldNameTerm->Type.PinCategory = CompilerContext.GetSchema()->PC_String;
+				FieldNameTerm->Source = Pin;
+				FieldNameTerm->Name = FieldName;
+				FieldNameTerm->TextLiteral = FText::FromString(FieldName);
+ 				FBlueprintCompiledStatement& Statement = Context.AppendStatementForNode(Node);
+				FName FunctionName;
+				bool bIsArray = Pin->PinType.bIsArray;
+				if (FieldType == CompilerContext.GetSchema()->PC_Boolean)
+				{
+					FunctionName = bIsArray ? TEXT("GetBoolArrayField") : TEXT("GetBoolField");
+				}
+				else if (FieldType == CompilerContext.GetSchema()->PC_Float)
+				{
+					FunctionName = bIsArray ? TEXT("GetNumberArrayField") : TEXT("GetNumberField");
+				}
+				else if (FieldType == CompilerContext.GetSchema()->PC_String)
+				{
+					FunctionName = bIsArray ? TEXT("GetStringArrayField") : TEXT("GetStringField");
+				}
+				else if (FieldType == CompilerContext.GetSchema()->PC_Object)
+				{
+					FunctionName = bIsArray ? TEXT("GetObjectArrayField") : TEXT("GetObjectField");
+				}
+				else
+				{
+					continue;
+				}
+			
+				UFunction *FunctionPtr = Class->FindFunctionByName(FunctionName);
+				Statement.Type = KCST_CallFunction;
+				Statement.FunctionToCall = FunctionPtr;
+				Statement.FunctionContext = *SourceTerm;
+				Statement.bIsParentContext = false;
+				Statement.LHS = *Target;
+				Statement.RHS.Add(FieldNameTerm);
+			}
+		}
+	}
+
+	FBPTerminal* RegisterInputTerm(FKismetFunctionContext& Context, UVaRest_BreakJson* Node)
+	{
+		//Find input pin
+		UEdGraphPin* InputPin = NULL;
+		for (int32 PinIndex = 0; PinIndex < Node->Pins.Num(); ++PinIndex)
+		{
+			UEdGraphPin* Pin = Node->Pins[PinIndex];
+			if (Pin && (EGPD_Input == Pin->Direction))
+			{
+				InputPin = Pin;
+				break;
+			}
+		}
+		check(NULL != InputPin);
+
+		//Find structure source net
+		UEdGraphPin* Net = FEdGraphUtilities::GetNetFromPin(InputPin);
+		FBPTerminal **TermPtr = Context.NetMap.Find(Net);
+		if (!TermPtr)
+		{
+			FBPTerminal *Term = Context.CreateLocalTerminalFromPinAutoChooseScope(Net, Context.NetNameMap->MakeValidName(Net));
+			Context.NetMap.Add(Net, Term);
+			return Term;
+		}
+		return *TermPtr;
+	}
+
+	void RegisterOutputTerm(FKismetFunctionContext& Context, UEdGraphPin* OutputPin, FBPTerminal* ContextTerm)
+	{
+		FBPTerminal *Term = Context.CreateLocalTerminalFromPinAutoChooseScope(OutputPin, OutputPin->PinName);
+		Context.NetMap.Add(OutputPin, Term);
+	}
+
+	virtual void RegisterNets(FKismetFunctionContext& Context, UEdGraphNode* InNode) override
+	{
+		UVaRest_BreakJson* Node = Cast<UVaRest_BreakJson>(InNode);
+		FNodeHandlingFunctor::RegisterNets(Context, Node);
+		check(NULL != Node);
+
+		if (FBPTerminal* StructContextTerm = RegisterInputTerm(Context, Node))
+		{
+			for (int32 PinIndex = 0; PinIndex < Node->Pins.Num(); ++PinIndex)
+			{
+				UEdGraphPin* Pin = Node->Pins[PinIndex];
+				if (NULL != Pin && EGPD_Output == Pin->Direction)
+				{
+					RegisterOutputTerm(Context, Pin, StructContextTerm);
+				}
+			}
+		}
+	}
+};
+
+
+UVaRest_BreakJson::UVaRest_BreakJson(const FObjectInitializer &ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+}
+
+FNodeHandlingFunctor* UVaRest_BreakJson::CreateNodeHandler(class FKismetCompilerContext& CompilerContext) const 
+{
+	return new FKCHandler_BreakJson(CompilerContext);
+}
+
+void UVaRest_BreakJson::AllocateDefaultPins()
+{
+	const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
+	UClass *Class = Cast<UClass>(StaticLoadObject(UClass::StaticClass(), NULL, TEXT("class'VaRestPlugin.VaRestJsonObject'")));
+	UEdGraphPin* Pin = CreatePin(EGPD_Input, K2Schema->PC_Object, TEXT(""), Class, false, false, TEXT("Target"));
+	K2Schema->SetPinDefaultValueBasedOnType(Pin);
+	CreateProjectionPins(Pin);
+}
+
+FLinearColor UVaRest_BreakJson::GetNodeTitleColor() const
+{
+	return FLinearColor(255.0f, 255.0f, 0.0f);
+}
+
+void UVaRest_BreakJson::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
+{
+
+	bool bIsDirty = false;
+	FName PropertyName = (PropertyChangedEvent.Property != NULL) ? PropertyChangedEvent.Property->GetFName() : NAME_None;
+	if (true || PropertyName == TEXT("Outputs"))
+	{
+		bIsDirty = true;
+	}
+
+	if (bIsDirty)
+	{
+		ReconstructNode();
+		GetGraph()->NotifyGraphChanged();
+	}
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+}
+// End UEdGraphNode interface.
+
+// Begin UK2Node interface
+
+void UVaRest_BreakJson::GetMenuActions(FBlueprintActionDatabaseRegistrar& ActionRegistrar) const
+{
+	// actions get registered under specific object-keys; the idea is that 
+	// actions might have to be updated (or deleted) if their object-key is  
+	// mutated (or removed)... here we use the node's class (so if the node 
+	// type disappears, then the action should go with it)
+	UClass* ActionKey = GetClass();
+	// to keep from needlessly instantiating a UBlueprintNodeSpawner, first   
+	// check to make sure that the registrar is looking for actions of this type
+	// (could be regenerating actions for a specific asset, and therefore the 
+	// registrar would only accept actions corresponding to that asset)
+	if (ActionRegistrar.IsOpenForRegistration(ActionKey))
+	{
+		UBlueprintNodeSpawner* NodeSpawner = UBlueprintNodeSpawner::Create(GetClass());
+		check(NodeSpawner != nullptr);
+
+		ActionRegistrar.AddBlueprintAction(ActionKey, NodeSpawner);
+	}
+}
+
+FText UVaRest_BreakJson::GetMenuCategory() const
+{
+	static FNodeTextCache CachedCategory;
+	if (CachedCategory.IsOutOfDate(this))
+	{
+		// FText::Format() is slow, so we cache this to save on performance
+		CachedCategory.SetCachedText(FEditorCategoryUtils::BuildCategoryString(FCommonEditorCategory::Utilities, LOCTEXT("ActionMenuCategory", "Va Rest")), this);
+	}
+	return CachedCategory;
+}
+// End UK2Node interface.
+
+
+void UVaRest_BreakJson::CreateProjectionPins(UEdGraphPin *Source)
+{
+	const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
+	UClass *Class = Cast<UClass>(StaticLoadObject(UClass::StaticClass(), NULL, TEXT("class'VaRestPlugin.VaRestJsonObject'")));
+	for (TArray<FVaRest_NamedType>::TIterator it(Outputs); it; ++it)
+	{
+		FString Type;
+		UObject *Subtype = nullptr;
+		FName FunctionName;
+		FString FieldName = (*it).Name;
+
+		switch ((*it).Type) {
+		case EVaRest_JsonType::JSON_Bool:
+			Type = K2Schema->PC_Boolean;
+			FunctionName = TEXT("GetBooleanField");
+			break;
+		case EVaRest_JsonType::JSON_Number:
+			Type = K2Schema->PC_Float;
+			FunctionName = TEXT("GetNumberField");
+			break;
+		case EVaRest_JsonType::JSON_String:
+			Type = K2Schema->PC_String;
+			FunctionName = TEXT("GetStringField");
+			break;
+		case EVaRest_JsonType::JSON_Object:
+			Type = K2Schema->PC_Object;
+			Subtype = Class;
+			FunctionName = TEXT("GetObjectField");
+			break;
+		}
+		if (FunctionName.IsNone()) {
+			continue;
+		}	
+		UEdGraphPin *OutputPin = CreatePin(EGPD_Output, Type, TEXT(""), Subtype, (*it).bIsArray, false, (*it).Name);
+	}
+}
+
+FText UVaRest_BreakJson::GetNodeTitle(ENodeTitleType::Type TitleType) const
+{
+	return LOCTEXT("VaRest_Break_Json.NodeTitle", "Break Json");
+}
+

--- a/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
+++ b/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
@@ -15,7 +15,7 @@
 
 class FKCHandler_BreakJson : public FNodeHandlingFunctor
 {
-	TArray<bool> bIsArray; // whether outputs are json arrays
+	
 public:
 	FKCHandler_BreakJson(FKismetCompilerContext& InCompilerContext)
 		: FNodeHandlingFunctor(InCompilerContext)
@@ -233,31 +233,22 @@ void UVaRest_BreakJson::CreateProjectionPins(UEdGraphPin *Source)
 	{
 		FString Type;
 		UObject *Subtype = nullptr;
-		FName FunctionName;
 		FString FieldName = (*it).Name;
-
 		switch ((*it).Type) {
 		case EVaRest_JsonType::JSON_Bool:
 			Type = K2Schema->PC_Boolean;
-			FunctionName = TEXT("GetBooleanField");
 			break;
 		case EVaRest_JsonType::JSON_Number:
 			Type = K2Schema->PC_Float;
-			FunctionName = TEXT("GetNumberField");
 			break;
 		case EVaRest_JsonType::JSON_String:
 			Type = K2Schema->PC_String;
-			FunctionName = TEXT("GetStringField");
 			break;
 		case EVaRest_JsonType::JSON_Object:
 			Type = K2Schema->PC_Object;
 			Subtype = Class;
-			FunctionName = TEXT("GetObjectField");
 			break;
 		}
-		if (FunctionName.IsNone()) {
-			continue;
-		}	
 		UEdGraphPin *OutputPin = CreatePin(EGPD_Output, Type, TEXT(""), Subtype, (*it).bIsArray, false, (*it).Name);
 	}
 }

--- a/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.h
+++ b/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.h
@@ -1,0 +1,53 @@
+#pragma once
+#include "Engine.h"
+#include "K2Node.h"
+#include "VaRest_BreakJson.generated.h"
+
+UENUM(BlueprintType)
+enum class EVaRest_JsonType : uint8
+{
+	//JSON_Null UMETA(DisplayName = "Null"),
+	JSON_Bool UMETA(DisplayName = "Boolean"),
+	JSON_Number UMETA(DisplayName = "Number"),
+	JSON_String UMETA(DisplayName = "String"),
+	JSON_Object UMETA(DisplayName = "Object")
+};
+
+USTRUCT(BlueprintType)
+struct FVaRest_NamedType
+{
+	GENERATED_USTRUCT_BODY();
+	UPROPERTY(EditAnywhere)
+		FString Name;
+	UPROPERTY(EditAnywhere)
+		EVaRest_JsonType Type;
+	UPROPERTY(EditAnywhere)
+		bool bIsArray;
+};
+
+UCLASS(BlueprintType, Blueprintable)
+class VARESTEDITORPLUGIN_API UVaRest_BreakJson : public UK2Node
+{
+	GENERATED_UCLASS_BODY()
+public:
+	UPROPERTY(EditAnywhere, Category = PinOptions)
+		TArray<FVaRest_NamedType> Outputs;
+	// Begin UEdGraphNode interface.
+	virtual void AllocateDefaultPins() override;
+	virtual FLinearColor GetNodeTitleColor() const override;
+	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+	// End UEdGraphNode interface.
+
+	// Begin UK2Node interface
+	virtual bool IsNodePure() const { return true; }
+	virtual bool ShouldShowNodeProperties() const { return true; }
+	void GetMenuActions(FBlueprintActionDatabaseRegistrar& ActionRegistrar) const override;
+	virtual FText GetMenuCategory() const override;
+	virtual FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
+	virtual class FNodeHandlingFunctor* CreateNodeHandler(class FKismetCompilerContext& CompilerContext) const override;
+	// End UK2Node interface.
+
+protected:
+	virtual void CreateProjectionPins(UEdGraphPin *Source);
+
+};

--- a/Source/VaRestEditorPlugin/Public/VaRestEditorPlugin.h
+++ b/Source/VaRestEditorPlugin/Public/VaRestEditorPlugin.h
@@ -1,0 +1,16 @@
+// Some copyright should be here...
+
+#pragma once
+
+#include "ModuleManager.h"
+
+
+
+class FVaRestEditorPluginModule : public IModuleInterface
+{
+public:
+
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/Source/VaRestEditorPlugin/VaRestEditorPlugin.Build.cs
+++ b/Source/VaRestEditorPlugin/VaRestEditorPlugin.Build.cs
@@ -1,0 +1,72 @@
+// Some copyright should be here...
+
+using UnrealBuildTool;
+
+public class VaRestEditorPlugin : ModuleRules
+{
+	public VaRestEditorPlugin(TargetInfo Target)
+	{
+		
+		PublicIncludePaths.AddRange(
+			new string[] {
+				"VaRestPlugin",
+				"VaRestPlugin/Public"
+				
+				// ... add public include paths required here ...
+			}
+			);
+				
+		
+		PrivateIncludePaths.AddRange(
+			new string[] {
+				"VaRestEditorPlugin/Private",
+				
+				// ... add other private include paths required here ...
+			}
+			);
+			
+		
+		PublicDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"Core",
+			        "VaRestPlugin"	
+				// ... add other public dependencies that you statically link with here ...
+			}
+			);
+			
+		
+		PrivateDependencyModuleNames.AddRange(
+			new string[]
+			{
+                            "CoreUObject",
+                            "Engine",
+                            "Slate",
+                            "SlateCore",
+                            "InputCore",
+                            "AssetTools",
+                            "UnrealEd", // for FAssetEditorManager
+                            "KismetWidgets",
+                            "KismetCompiler",
+                            "BlueprintGraph",
+                            "GraphEditor",
+                            "Kismet",  // for FWorkflowCentricApplication
+                            "PropertyEditor",
+                            "EditorStyle",
+                            "Sequencer",
+                            "DetailCustomizations",
+                            "Settings",
+                            "RenderCore"	
+			}
+			);
+		
+		
+		DynamicallyLoadedModuleNames.AddRange(
+			new string[]
+			{
+				
+				// ... add any modules that your module loads dynamically here ...
+			}
+			);
+	}
+}

--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -75,7 +75,7 @@ namespace ERequestContentType
 	enum Type
 	{
 		x_www_form_urlencoded,
-		json
+		json,
 		binary
 	};
 }
@@ -124,7 +124,7 @@ public:
 	/** Sets optional header info */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Request")
 	void SetHeader(const FString& HeaderName, const FString& HeaderValue);
-Se
+
 	/** Applies percent-encoding to text */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Utility")
 	static FString PercentEncode(const FString& Text);
@@ -162,7 +162,7 @@ Se
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Response")
 	UVaRestJsonObject* GetResponseObject();
 
-xo	/** Set the Response Json object */
+	/** Set the Response Json object */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Response")
 	void SetResponseObject(UVaRestJsonObject* JsonObject);
 
@@ -190,8 +190,8 @@ xo	/** Set the Response Json object */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Request")
 	virtual void ProcessURL(const FString& Url = TEXT("http://alyamkin.com"));
 
-        UFUNCTION(BlueprintCallable, Category = "VaRest|Request", meta = (Latent, WorldContext = "WorldContextObject", LatentInfo = "LatentInfo"))
-        virtual void ApplyURL(const FString& Url, UVaRestJsonObject *&Result, UObject* WorldContextObject, struct FLatentActionInfo LatentInfo);
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Request", meta = (Latent, WorldContext = "WorldContextObject", LatentInfo = "LatentInfo"))
+	virtual void ApplyURL(const FString& Url, UVaRestJsonObject *&Result, UObject* WorldContextObject, struct FLatentActionInfo LatentInfo);
 
 
 	/** Apply current internal setup to request and process it */

--- a/VaRestPlugin.uplugin
+++ b/VaRestPlugin.uplugin
@@ -2,8 +2,8 @@
     "FileVersion" : 3,
 	
 	"FriendlyName" : "VaRest",
-	"Version" : 9,
-	"VersionName" : "1.1-r9",
+	"Version" : 7,
+	"VersionName" : "1.1-rc7",
 	"CreatedBy" : "Vladimir Alyamkin",
 	"CreatedByURL" : "http://alyamkin.com",
 	"EngineVersion" : 1579795,
@@ -16,6 +16,10 @@
 			"Name" : "VaRestPlugin",
 			"Type" : "Runtime",
             "LoadingPhase": "PreDefault"
+		},
+		{
+			"Name": "VaRestEditorPlugin",
+			"Type": "Editor"
 		}
 	]
 }

--- a/VaRestPlugin.uplugin
+++ b/VaRestPlugin.uplugin
@@ -2,8 +2,8 @@
     "FileVersion" : 3,
 	
 	"FriendlyName" : "VaRest",
-	"Version" : 7,
-	"VersionName" : "1.1-rc7",
+	"Version" : 9,
+	"VersionName" : "1.1-rc9",
 	"CreatedBy" : "Vladimir Alyamkin",
 	"CreatedByURL" : "http://alyamkin.com",
 	"EngineVersion" : 1579795,


### PR DESCRIPTION
1) For our purposes, e.g speech recognition, the request content is sometimes binary while the response is json. We added an option to support this use case. Specifically there are two new functions on VaRestJsonRequest, namely SetBinaryContentType(FString) and SetBinaryRequestContent(TArray<uint8>) and an additional "binary" enumerator on ERequestContentType.
2) Added a new function "ApplyURL" which works like ProcessURL but doesn't require using an event to handle the response. Instead the response is returned directly via the engine's latent action mechanism.
3) Added an editor plugin that provides a custom "Break Json" node which can be used to access the properties of JSON objects. The properties can be added via the Pin options of the editor. Code is generated that calls GetXXX[Array]Field as appropriate.