### PR TITLE
Added Http.h include to VaRestRequestJSON.h

### DIFF
--- a/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/Json/VaRestRequestJSON.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Http.h"
 #include "VaRestRequestJSON.generated.h"
 
 /** Verb (GET, PUT, POST) used by the request */


### PR DESCRIPTION
This allows inclusion of `VaRestPlugin` in `PrivateIncludePathModuleNames`, so you can use the plugin from C++.

When I tried including `VaRestRequestJSON.h` in my code, I got errors regarding the `FHttpRequestPtr` used on line 142. Including `Http.h` fixed this.