### PR TITLE
GetIntegerField and SetIntegerField methods

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -95,6 +95,14 @@ class VARESTPLUGIN_API UVaRestJsonObject : public UObject
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
 	void SetNumberField(const FString& FieldName, float Number);
 
+	/** Get the field named FieldName as an Integer. Ensures that the field is present and is of type Json number. */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
+	int32 GetIntegerField(const FString& FieldName) const;
+
+	/** Add a field named FieldName with Integer as value. */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
+	void SetIntegerField(const FString& FieldName, int32 Number);
+
 	/** Get the field named FieldName as a string. */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
 	FString GetStringField(const FString& FieldName) const;

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -180,7 +180,7 @@ int32 UVaRestJsonObject::GetIntegerField(const FString& FieldName) const
 	if (!JsonObj.IsValid() || !JsonObj->HasTypedField<EJson::Number>(FieldName))
 	{
 		UE_LOG(LogVaRest, Warning, TEXT("No field with name %s of type Number"), *FieldName);
-		return 0.0f;
+		return 0;
 	}
 
 	return JsonObj->GetIntegerField(FieldName);

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -175,6 +175,27 @@ void UVaRestJsonObject::SetNumberField(const FString& FieldName, float Number)
 	JsonObj->SetNumberField(FieldName, Number);
 }
 
+int32 UVaRestJsonObject::GetIntegerField(const FString& FieldName) const
+{
+	if (!JsonObj.IsValid() || !JsonObj->HasTypedField<EJson::Number>(FieldName))
+	{
+		UE_LOG(LogVaRest, Warning, TEXT("No field with name %s of type Number"), *FieldName);
+		return 0.0f;
+	}
+
+	return JsonObj->GetIntegerField(FieldName);
+}
+
+void UVaRestJsonObject::SetIntegerField(const FString& FieldName, int32 Number)
+{
+	if (!JsonObj.IsValid() || FieldName.IsEmpty())
+	{
+		return;
+	}
+
+	JsonObj->SetNumberField(FieldName, Number);
+}
+
 FString UVaRestJsonObject::GetStringField(const FString& FieldName) const
 {
 	if (!JsonObj.IsValid() || !JsonObj->HasTypedField<EJson::String>(FieldName))


### PR DESCRIPTION
I added two new methods on the JsonObject, `GetIntegerField` and `SetIntegerField`.

For people that have integer numbers in their JSON documents and can't use `float` to represent them.