### PR TITLE
Make VaRest IWYU compatible

### DIFF
--- a/Source/VaRestEditorPlugin/Private/VaRestEditorPlugin.cpp
+++ b/Source/VaRestEditorPlugin/Private/VaRestEditorPlugin.cpp
@@ -1,8 +1,8 @@
 // Copyright 2015 Vladimir Alyamkin. All Rights Reserved.
 // Original code by https://github.com/unktomi
 
-#include "VaRestEditorPluginPrivatePCH.h"
 #include "VaRestEditorPlugin.h"
+#include "VaRestEditorPluginPrivatePCH.h"
 
 #define LOCTEXT_NAMESPACE "FVaRestEditorPluginModule"
 

--- a/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
+++ b/Source/VaRestEditorPlugin/Private/VaRest_BreakJson.cpp
@@ -1,8 +1,8 @@
 // Copyright 2015 Vladimir Alyamkin. All Rights Reserved.
 // Original code by https://github.com/unktomi
 
-#include "VaRestEditorPluginPrivatePCH.h"
 #include "VaRest_BreakJson.h"
+#include "VaRestEditorPluginPrivatePCH.h"
 
 #include "Runtime/Launch/Resources/Version.h"
 #include "EdGraphUtilities.h"

--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "JsonObject.h"
 #include "VaRestJsonObject.generated.h"
 
 class UVaRestJsonValue;

--- a/Source/VaRestPlugin/Classes/VaRestJsonValue.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonValue.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "JsonValue.h"
 #include "VaRestJsonValue.generated.h"
 
 class UVaRestJsonObject;

--- a/Source/VaRestPlugin/Classes/VaRestLibrary.h
+++ b/Source/VaRestPlugin/Classes/VaRestLibrary.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "Kismet/BlueprintFunctionLibrary.h"
+#include "Object.h"
+#include "IDelegateInstance.h"
 
 #include "VaRestTypes.h"
 #include "VaRestLibrary.generated.h"

--- a/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
@@ -4,7 +4,7 @@
 
 #include "Engine/LatentActionManager.h"
 #include "Http.h"
-
+#include "LatentActions.h"
 #include "VaRestTypes.h"
 #include "VaRestRequestJSON.generated.h"
 

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -1,5 +1,6 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
 
+#include "VaRestJsonObject.h"
 #include "VaRestPluginPrivatePCH.h"
 
 typedef TJsonWriterFactory< TCHAR, TCondensedJsonPrintPolicy<TCHAR> > FCondensedJsonStringWriterFactory;

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -2,6 +2,10 @@
 
 #include "VaRestJsonObject.h"
 #include "VaRestPluginPrivatePCH.h"
+#include "JsonSerializer.h"
+#include "JsonValue.h"
+#include "VaRestJsonValue.h"
+#include "Array.h"
 
 typedef TJsonWriterFactory< TCHAR, TCondensedJsonPrintPolicy<TCHAR> > FCondensedJsonStringWriterFactory;
 typedef TJsonWriter< TCHAR, TCondensedJsonPrintPolicy<TCHAR> > FCondensedJsonStringWriter;

--- a/Source/VaRestPlugin/Private/VaRestJsonValue.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonValue.cpp
@@ -1,6 +1,6 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
 
-#include "VaRestJsonValue"
+#include "VaRestJsonValue.h"
 #include "VaRestPluginPrivatePCH.h"
 
 UVaRestJsonValue::UVaRestJsonValue(const class FObjectInitializer& PCIP)

--- a/Source/VaRestPlugin/Private/VaRestJsonValue.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonValue.cpp
@@ -1,5 +1,6 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
 
+#include "VaRestJsonValue"
 #include "VaRestPluginPrivatePCH.h"
 
 UVaRestJsonValue::UVaRestJsonValue(const class FObjectInitializer& PCIP)

--- a/Source/VaRestPlugin/Private/VaRestLibrary.cpp
+++ b/Source/VaRestPlugin/Private/VaRestLibrary.cpp
@@ -1,5 +1,6 @@
 // Copyright 2016 Vladimir Alyamkin. All Rights Reserved.
 
+#include "VaRestLibrary.h"
 #include "VaRestPluginPrivatePCH.h"
 #include "Base64.h"
 

--- a/Source/VaRestPlugin/Private/VaRestRequestJSON.cpp
+++ b/Source/VaRestPlugin/Private/VaRestRequestJSON.cpp
@@ -1,5 +1,6 @@
 // Copyright 2014 Vladimir Alyamkin. All Rights Reserved.
 
+#include "VaRestRequestJSON.h"
 #include "VaRestPluginPrivatePCH.h"
 #include "CoreMisc.h"
 


### PR DESCRIPTION
Hey, We're including VaRest in our custom engine builds, and it threw a bunch of errors because the code wasn't in accordance with Unreal's Import-What-You-Use guidelines (https://docs.unrealengine.com/latest/INT/Programming/UnrealBuildSystem/IWYUReferenceGuide/). 
Including the necessary header files in these commits :)