### PR TITLE
Added getter for http request

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
@@ -327,5 +327,8 @@ protected:
 
 	/** Request we're currently processing */
 	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
-
+	
+public:
+	/** Returns reference to internal request object. */
+	TSharedRef<IHttpRequest> GetHttpRequest() const { return HttpRequest; };
 };

--- a/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
+++ b/Source/VaRestPlugin/Classes/VaRestRequestJSON.h
@@ -329,6 +329,7 @@ protected:
 	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
 	
 public:
-	/** Returns reference to internal request object. */
+	/** Returns reference to internal request object */
 	TSharedRef<IHttpRequest> GetHttpRequest() const { return HttpRequest; };
+	
 };


### PR DESCRIPTION
This is useful when you want to directly access response's bytes. As those are currently only stored in local variable (https://github.com/ufna/VaRest/blob/develop/Source/VaRestPlugin/Private/VaRestRequestJSON.cpp#L463)
Our backed sometimes compresses data into bytes and this give us possibility to read them thru VaRestRequestJSON.