### PR TITLE
Use percent encoding function from FGenericPlatformHttp.

### DIFF
--- a/Source/VaRestPlugin/Private/VaRestLibrary.cpp
+++ b/Source/VaRestPlugin/Private/VaRestLibrary.cpp
@@ -11,32 +11,7 @@
 
 FString UVaRestLibrary::PercentEncode(const FString& Source)
 {
-	FString OutText = Source;
-	
-	OutText = OutText.Replace(TEXT(" "), TEXT("%20"));
-	OutText = OutText.Replace(TEXT("!"), TEXT("%21"));
-	OutText = OutText.Replace(TEXT("\""), TEXT("%22"));
-	OutText = OutText.Replace(TEXT("#"), TEXT("%23"));
-	OutText = OutText.Replace(TEXT("$"), TEXT("%24"));
-	OutText = OutText.Replace(TEXT("&"), TEXT("%26"));
-	OutText = OutText.Replace(TEXT("'"), TEXT("%27"));
-	OutText = OutText.Replace(TEXT("("), TEXT("%28"));
-	OutText = OutText.Replace(TEXT(")"), TEXT("%29"));
-	OutText = OutText.Replace(TEXT("*"), TEXT("%2A"));
-	OutText = OutText.Replace(TEXT("+"), TEXT("%2B"));
-	OutText = OutText.Replace(TEXT(","), TEXT("%2C"));
-	OutText = OutText.Replace(TEXT("/"), TEXT("%2F"));
-	OutText = OutText.Replace(TEXT(":"), TEXT("%3A"));
-	OutText = OutText.Replace(TEXT(";"), TEXT("%3B"));
-	OutText = OutText.Replace(TEXT("="), TEXT("%3D"));
-	OutText = OutText.Replace(TEXT("?"), TEXT("%3F"));
-	OutText = OutText.Replace(TEXT("@"), TEXT("%40"));
-	OutText = OutText.Replace(TEXT("["), TEXT("%5B"));
-	OutText = OutText.Replace(TEXT("]"), TEXT("%5D"));
-	OutText = OutText.Replace(TEXT("{"), TEXT("%7B"));
-	OutText = OutText.Replace(TEXT("}"), TEXT("%7D"));
-	
-	return OutText;
+	return FGenericPlatformHttp::UrlEncode(Source);
 }
 
 FString UVaRestLibrary::Base64Encode(const FString& Source)


### PR DESCRIPTION
This also converts characters outside the unreserved set to UTF-8 bytes, fixing an issue I had with using non-ASCII characters in fields in GET requests.