### PR TITLE
'No Content' content type added

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestTypes.h
+++ b/Source/VaRestPlugin/Classes/VaRestTypes.h
@@ -21,7 +21,8 @@ enum class ERequestContentType : uint8
 	x_www_form_urlencoded_url	UMETA(DisplayName = "x-www-form-urlencoded (URL)"),
 	x_www_form_urlencoded_body	UMETA(DisplayName = "x-www-form-urlencoded (Request Body)"),
 	json,
-	binary
+	binary,
+	no_content
 };
 
 /** Enumerates the current state of an Http request */


### PR DESCRIPTION
'No Content' content type added, which can be used to remove Content-Type & Content-Length fields from request