### PR TITLE
Add missed const qualifier

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -28,7 +28,7 @@ class VARESTPLUGIN_API UVaRestJsonObject : public UObject
 	TSharedPtr<FJsonObject>& GetRootObject();
 
 	/** Set the root Json object */
-	void SetRootObject(TSharedPtr<FJsonObject>& JsonObject);
+	void SetRootObject(const TSharedPtr<FJsonObject>& JsonObject);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Serialization

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -34,7 +34,7 @@ TSharedPtr<FJsonObject>& UVaRestJsonObject::GetRootObject()
 	return JsonObj;
 }
 
-void UVaRestJsonObject::SetRootObject(TSharedPtr<FJsonObject>& JsonObject)
+void UVaRestJsonObject::SetRootObject(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	if (JsonObject.IsValid())
 	{


### PR DESCRIPTION
Just missed `const`. But it is necessary if you want to put temporary `TSharedPtr<FJsonObject>` as a `JsonObject` argument. Temporary object cannot be casted to non-const reference.  