### PR TITLE
saving json to file exposed to blueprints

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -179,13 +179,10 @@ public:
 	/** Save json to file */
 	bool WriteToFile(const FString& Path);
 
-	/** Blueprint Save json to absolute filepath */
+	/** Blueprint Save json to filepath */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
-	bool WriteToFileAbsolute(const FString& AbsPath);
+	bool WriteToFilePath(const FString& Path, bool bIsRelativePath = true);
 
-	/** Blueprint Save json to relative filepath */
-	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
-	bool WriteToFileRelative(const FString& RelPath);
 
 	static bool WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len);
 

--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -179,6 +179,14 @@ public:
 	/** Save json to file */
 	bool WriteToFile(const FString& Path);
 
+	/** Blueprint Save json to absolute filepath */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
+	bool WriteToFileAbsolute(const FString& AbsPath);
+
+	/** Blueprint Save json to relative filepath */
+	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
+	bool WriteToFileRelative(const FString& RelPath);
+
 	static bool WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len);
 
 	//////////////////////////////////////////////////////////////////////////

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -657,6 +657,8 @@ void UVaRestJsonObject::DecodeFromArchive(TUniquePtr<FArchive>& Reader)
 	}
 }
 
+
+
 bool UVaRestJsonObject::WriteToFile(const FString& Path)
 {
 	TUniquePtr<FArchive> FileWriter(IFileManager::Get().CreateFileWriter(*Path));
@@ -708,6 +710,17 @@ bool UVaRestJsonObject::WriteToFile(const FString& Path)
 	FileWriter->Close();
 
 	return true;
+}
+
+bool UVaRestJsonObject::WriteToFileAbsolute(const FString& AbsPath)
+{
+	return WriteToFile(AbsPath);
+}
+
+bool UVaRestJsonObject::WriteToFileRelative(const FString& RelPath)
+{
+	FString FullJsonPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / RelPath);
+	return WriteToFile(FullJsonPath);
 }
 
 bool UVaRestJsonObject::WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len)

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -712,15 +712,17 @@ bool UVaRestJsonObject::WriteToFile(const FString& Path)
 	return true;
 }
 
-bool UVaRestJsonObject::WriteToFileAbsolute(const FString& AbsPath)
+bool UVaRestJsonObject::WriteToFilePath(const FString& Path, bool bIsRelativePath)
 {
-	return WriteToFile(AbsPath);
-}
-
-bool UVaRestJsonObject::WriteToFileRelative(const FString& RelPath)
-{
-	FString FullJsonPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / RelPath);
-	return WriteToFile(FullJsonPath);
+	if (bIsRelativePath)
+	{
+		FString FullJsonPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / Path);
+		return WriteToFile(FullJsonPath);
+	}
+	else
+	{
+		return WriteToFile(Path);
+	}
 }
 
 bool UVaRestJsonObject::WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len)


### PR DESCRIPTION
Hello :)

When looking for a way to save JSON to disk I found that there was such a Method, but it wasn't exposed to Blueprints. I have made minimal changes to add nodes for writing to files with absolute path as well as relative to ProjectDir.

Is there a reason these haven't been exposed? Can you tell me why "writetofile" is located under "deserialization" instead of "serialization" as I would have expected?

Cheers,
Tyrius

(Please forgive any ignorance on my part, this is my first PR ever. If there is anything odd in this PR, I would also appreciate any advice on do's/don'ts and how to improve my future PRs.)

