### PR TITLE
Make loading and saving from paths more flexible

### DIFF
--- a/Source/VaRestPlugin/Classes/VaRestJsonObject.h
+++ b/Source/VaRestPlugin/Classes/VaRestJsonObject.h
@@ -183,9 +183,11 @@ public:
 	/** Save json to file */
 	bool WriteToFile(const FString& Path);
 
-	/** Blueprint Save json to filepath */
+	/** Blueprint Save json to filepath 
+	 * @param    BasePath    prepended to the Path, leave empty if absolute Path is used
+	 */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Json")
-	bool WriteToFilePath(const FString& Path, bool bIsRelativePath = true);
+	bool WriteToFilePath(const FString& Path, const FString& BasePath);
 
 	static bool WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len);
 

--- a/Source/VaRestPlugin/Classes/VaRestLibrary.h
+++ b/Source/VaRestPlugin/Classes/VaRestLibrary.h
@@ -97,10 +97,10 @@ public:
 public:
 	/** 
 	 * Load JSON from formatted text file
-	 * @param Path		File name relative to the Content folder
+	 * @param BasePath  Prepended to the Path, leave empty if absolute Path is used
 	 */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Utility", meta = (WorldContext = "WorldContextObject"))
-	static class UVaRestJsonObject* LoadJsonFromFile(UObject* WorldContextObject, const FString& Path);
+	static class UVaRestJsonObject* LoadJsonFromFile(UObject* WorldContextObject, const FString& Path, const FString& BasePath);
 
 	//////////////////////////////////////////////////////////////////////////
 	// Easy URL processing

--- a/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
+++ b/Source/VaRestPlugin/Private/VaRestJsonObject.cpp
@@ -713,17 +713,9 @@ bool UVaRestJsonObject::WriteToFile(const FString& Path)
 	return true;
 }
 
-bool UVaRestJsonObject::WriteToFilePath(const FString& Path, bool bIsRelativePath)
+bool UVaRestJsonObject::WriteToFilePath(const FString& Path, const FString& BasePath)
 {
-	if (bIsRelativePath)
-	{
-		FString FullJsonPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / Path);
-		return WriteToFile(FullJsonPath);
-	}
-	else
-	{
-		return WriteToFile(Path);
-	}
+	return WriteToFile(BasePath / Path);
 }
 
 bool UVaRestJsonObject::WriteStringToArchive(FArchive& Ar, const TCHAR* StrPtr, int64 Len)

--- a/Source/VaRestPlugin/Private/VaRestLibrary.cpp
+++ b/Source/VaRestPlugin/Private/VaRestLibrary.cpp
@@ -43,12 +43,12 @@ bool UVaRestLibrary::Base64DecodeData(const FString& Source, TArray<uint8>& Dest
 //////////////////////////////////////////////////////////////////////////
 // File system integration
 
-class UVaRestJsonObject* UVaRestLibrary::LoadJsonFromFile(UObject* WorldContextObject, const FString& Path)
+class UVaRestJsonObject* UVaRestLibrary::LoadJsonFromFile(UObject* WorldContextObject, const FString& Path, const FString& BasePath)
 {
 	UVaRestJsonObject* Json = UVaRestJsonObject::ConstructJsonObject(WorldContextObject);
-
+	
 	FString JSONString;
-	if (FFileHelper::LoadFileToString(JSONString, *(FPaths::ProjectContentDir() + Path)))
+	if (FFileHelper::LoadFileToString(JSONString, *(BasePath / Path)))
 	{
 		if (Json->DecodeJson(JSONString))
 		{


### PR DESCRIPTION
A while ago I worked on reading/writing files.
Not that I had to use it more extensively I realized I needed the functions to be more flexible in regards to absolute/relative paths and base-directories.

Problem is the changes are breaking, since the functions had assumptions what directory the supplied path is relative to, whereas now there is a parameter for basedir.

Since the nodes were only recently exposed I doubt they are used too much, and existing blueprint code can also easily be adapted to the new paramters.

What do you think?