### PR TITLE
Update 'VaRest.uplugin' file

### DIFF
--- a/VaRest.uplugin
+++ b/VaRest.uplugin
@@ -6,7 +6,7 @@
 	"VersionName" : "1.1-r27",
 	"CreatedBy" : "Vladimir Alyamkin",
 	"CreatedByURL" : "https://alyamkin.com",
-	"EngineVersion" : "4.23.0",
+	"EngineVersion" : "4.24.0",
 	"Description" : "Plugin that makes REST (JSON) server communication easy to use",
 	"Category" : "Network",
 	"MarketplaceURL" : "com.epicgames.launcher://ue/marketplace/content/e47be161e7a24e928560290abd5dcc4f",


### PR DESCRIPTION
Additional small change specially for non-cpp project.

Without that fix non-cpp project never would opened as compiled plugin - need to be recompiled manually (in cpp project, with xcode etc.)

PS: tested on iOS as packaged 'development', 'shipping' from non-cpp project.