### PR TITLE
Missing category

### DIFF
--- a/Source/VaRest/Public/VaRestLibrary.h
+++ b/Source/VaRest/Public/VaRestLibrary.h
@@ -105,6 +105,6 @@ public:
 	/**
 	 * Get the URL that was used when loading this World
 	 */
-	UFUNCTION(BlueprintPure, meta = (WorldContext = "WorldContextObject"))
+	UFUNCTION(BlueprintPure, Category = "VaRest|Utility", meta = (WorldContext = "WorldContextObject"))
 	static FVaRestURL GetWorldURL(UObject* WorldContextObject);
 };


### PR DESCRIPTION
Added category to the GetWorldURL node

Fixes the following error on shipping build:
`C:/Program Files/Epic Games/UE_4.25/Engine/Plugins/Marketplace/VaRestPlugin/Source/VaRest/Public/VaRestLibrary.h(109) : LogCompile: Error: An explicit Category specifier is required for Blueprint accessible functions in an Engine module.`