### PR TITLE
Changed Result in ApplyURL from UVaRestJsonObject to UVaRestRequestJSON

### DIFF
--- a/Source/VaRest/Private/VaRestRequestJSON.cpp
+++ b/Source/VaRest/Private/VaRestRequestJSON.cpp
@@ -248,7 +248,7 @@ void UVaRestRequestJSON::ProcessURL(const FString& Url)
 	ProcessRequest();
 }
 
-void UVaRestRequestJSON::ApplyURL(const FString& Url, UVaRestJsonObject*& Result, UObject* WorldContextObject, FLatentActionInfo LatentInfo)
+void UVaRestRequestJSON::ApplyURL(const FString& Url, UVaRestRequestJSON*& Result, UObject* WorldContextObject, FLatentActionInfo LatentInfo)
 {
 	// Be sure to trim URL because it can break links on iOS
 	FString TrimmedUrl = Url;
@@ -262,7 +262,7 @@ void UVaRestRequestJSON::ApplyURL(const FString& Url, UVaRestJsonObject*& Result
 	if (UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject))
 	{
 		FLatentActionManager& LatentActionManager = World->GetLatentActionManager();
-		FVaRestLatentAction<UVaRestJsonObject*>* Kont = LatentActionManager.FindExistingAction<FVaRestLatentAction<UVaRestJsonObject*>>(LatentInfo.CallbackTarget, LatentInfo.UUID);
+		FVaRestLatentAction<UVaRestRequestJSON*>* Kont = LatentActionManager.FindExistingAction<FVaRestLatentAction<UVaRestRequestJSON*>>(LatentInfo.CallbackTarget, LatentInfo.UUID);
 
 		if (Kont != nullptr)
 		{
@@ -270,7 +270,7 @@ void UVaRestRequestJSON::ApplyURL(const FString& Url, UVaRestJsonObject*& Result
 			LatentActionManager.RemoveActionsForObject(LatentInfo.CallbackTarget);
 		}
 
-		LatentActionManager.AddNewAction(LatentInfo.CallbackTarget, LatentInfo.UUID, ContinueAction = new FVaRestLatentAction<UVaRestJsonObject*>(this, Result, LatentInfo));
+		LatentActionManager.AddNewAction(LatentInfo.CallbackTarget, LatentInfo.UUID, ContinueAction = new FVaRestLatentAction<UVaRestRequestJSON*>(this, Result, LatentInfo));
 	}
 
 	ProcessRequest();
@@ -548,10 +548,10 @@ void UVaRestRequestJSON::OnProcessRequestComplete(FHttpRequestPtr Request, FHttp
 	// Finish the latent action
 	if (ContinueAction)
 	{
-		FVaRestLatentAction<UVaRestJsonObject*>* K = ContinueAction;
+		FVaRestLatentAction<UVaRestRequestJSON*>* K = ContinueAction;
 		ContinueAction = nullptr;
 
-		K->Call(ResponseJsonObj);
+		K->Call(this);
 	}
 }
 

--- a/Source/VaRest/Public/VaRestRequestJSON.h
+++ b/Source/VaRest/Public/VaRestRequestJSON.h
@@ -203,7 +203,7 @@ public:
 
 	/** Open URL in latent mode */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Request", meta = (Latent, LatentInfo = "LatentInfo", HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"))
-	virtual void ApplyURL(const FString& Url, UVaRestJsonObject*& Result, UObject* WorldContextObject, struct FLatentActionInfo LatentInfo);
+	virtual void ApplyURL(const FString& Url, UVaRestRequestJSON*& Result, UObject* WorldContextObject, struct FLatentActionInfo LatentInfo);
 
 	/** Check URL and execute process request */
 	UFUNCTION(BlueprintCallable, Category = "VaRest|Request")
@@ -289,7 +289,7 @@ protected:
 
 protected:
 	/** Latent action helper */
-	FVaRestLatentAction<UVaRestJsonObject*>* ContinueAction;
+	FVaRestLatentAction<UVaRestRequestJSON*>* ContinueAction;
 
 	/** Internal request data stored as JSON */
 	UPROPERTY()


### PR DESCRIPTION
For accessing more information such as GetResponseContentAsString(), which is useful, for example, when API provider sends csv instead of json.