### PR TITLE
Added support for getting field type as string representation

### DIFF
--- a/Source/VaRest/Private/VaRestJsonObject.cpp
+++ b/Source/VaRest/Private/VaRestJsonObject.cpp
@@ -128,7 +128,6 @@ FString UVaRestJsonObject::GetFieldTypeString(const FString& FieldName) const
 
 	UE_LOG(LogVaRest, Warning, TEXT("Field with name %s type unkonwn."), *FieldName);
 	return "";
-
 }
 
 TArray<FString> UVaRestJsonObject::GetFieldNames() const

--- a/Source/VaRest/Private/VaRestJsonObject.cpp
+++ b/Source/VaRest/Private/VaRestJsonObject.cpp
@@ -99,6 +99,38 @@ bool UVaRestJsonObject::DecodeJson(const FString& JsonString, bool bUseIncrement
 //////////////////////////////////////////////////////////////////////////
 // FJsonObject API
 
+FString UVaRestJsonObject::GetFieldTypeString(const FString& FieldName) const
+{
+	if (!JsonObj->HasTypedField<EJson::Null>(FieldName))
+	{
+		return TEXT("Null");
+	}
+	else if (!JsonObj->HasTypedField<EJson::String>(FieldName))
+	{
+		return TEXT("String");
+	}
+	else if (!JsonObj->HasTypedField<EJson::Number>(FieldName))
+	{
+		return TEXT("Number");
+	}
+	else if (!JsonObj->HasTypedField<EJson::Boolean>(FieldName))
+	{
+		return TEXT("Boolean");
+	}
+	else if (!JsonObj->HasTypedField<EJson::Object>(FieldName))
+	{
+		return TEXT("Object");
+	}
+	else if (!JsonObj->HasTypedField<EJson::Array>(FieldName))
+	{
+		return TEXT("Array");
+	}
+
+	UE_LOG(LogVaRest, Warning, TEXT("Field with name %s type unkonwn."), *FieldName);
+	return "";
+
+}
+
 TArray<FString> UVaRestJsonObject::GetFieldNames() const
 {
 	TArray<FString> Result;

--- a/Source/VaRest/Private/VaRestJsonObject.cpp
+++ b/Source/VaRest/Private/VaRestJsonObject.cpp
@@ -126,7 +126,7 @@ FString UVaRestJsonObject::GetFieldTypeString(const FString& FieldName) const
 		return TEXT("Array");
 	}
 
-	UE_LOG(LogVaRest, Warning, TEXT("Field with name %s type unkonwn."), *FieldName);
+	UE_LOG(LogVaRest, Warning, TEXT("Field with name %s type unknown"), *FieldName);
 	return "";
 }
 

--- a/Source/VaRest/Public/VaRestJsonObject.h
+++ b/Source/VaRest/Public/VaRestJsonObject.h
@@ -48,6 +48,10 @@ public:
 	//////////////////////////////////////////////////////////////////////////
 	// FJsonObject API
 
+	/** Gets the type of value as string for a given field */
+	UFUNCTION(BlueprintPure, Category = "VaRest|Json")
+	FString GetFieldTypeString(const FString& FieldName) const;
+
 	/** Returns a list of field names that exist in the object */
 	UFUNCTION(BlueprintPure, Category = "VaRest|Json")
 	TArray<FString> GetFieldNames() const;


### PR DESCRIPTION
Currently there is no support for determining the type of a field before trying to extract it and cast it (ie. get number field, get object field). Sometimes fields can contain various value representation such as null, array, object, etc while having the same field name. This adds another layer to allow type checking checking before casting with the getting as functions.