### PR TITLE
Update for 5.2

### DIFF
--- a/Source/VaRest/Public/VaRestJsonObject.h
+++ b/Source/VaRest/Public/VaRestJsonObject.h
@@ -165,11 +165,11 @@ private:
 		for (auto& field : Fields)
 		{
 			// No need to support all int types as they're not supported by BP
-			if (TIsSame<T, uint8>::Value || TIsSame<T, int32>::Value || TIsSame<T, int64>::Value || TIsSame<T, float>::Value)
+			if (std::is_same_v<T, uint8> || std::is_same_v<T, int32>|| std::is_same_v<T, int64> || std::is_same_v<T, float>)
 			{
 				SetNumberField(field.Key, field.Value);
 			}
-			else if (TIsSame<T, bool>::Value)
+			else if (std::is_same_v<T, bool>)
 			{
 				SetBoolField(field.Key, (bool)field.Value);
 			}

--- a/VaRest.uplugin
+++ b/VaRest.uplugin
@@ -6,7 +6,7 @@
 	"VersionName" : "1.1-r32",
 	"CreatedBy" : "Vladimir Alyamkin",
 	"CreatedByURL" : "https://ufna.dev",
-	"EngineVersion" : "5.1.0",
+	"EngineVersion" : "5.2.0",
 	"Description" : "Plugin that makes REST (JSON) server communication easy to use",
 	"Category" : "Network",
 	"DocsURL": "https://bit.ly/VaRest-Docs",


### PR DESCRIPTION
Updated the code to adhere to the TIsSame<> deprecation warning of 5.2:
` warning: 'TIsSame<bool, unsigned char>' is deprecated: TIsSame has been deprecated, please use std::is_same instead.`